### PR TITLE
Removed `filename` method and related documentation from presets

### DIFF
--- a/docs/snippets/receipt-instagram-feed.php
+++ b/docs/snippets/receipt-instagram-feed.php
@@ -49,9 +49,4 @@ class InstagramFeed extends InstagramFeedPreset
                 ],
             ]);
     }
-
-    public function filename(): string
-    {
-        return 'instagram.xml';
-    }
 }

--- a/docs/topics/presets.topic
+++ b/docs/topics/presets.topic
@@ -37,10 +37,6 @@
     <code-block lang="php" src="receipt-instagram-feed.php" include-lines="5-" />
 
     <p>
-        If needed, you can also override the <code>filename</code> method to change the output file name.
-    </p>
-
-    <p>
         Technically, preset classes are the same as the base
         <code>Feed</code> class, except they include the service-specific logic they target, including how information blocks and items are built.
     </p>


### PR DESCRIPTION
<!--
- Fill in the form below correctly. This will help the Pest team to understand the PR and also work on it.
-->

### What:

- [ ] Bug Fix
- [ ] New Feature

### Description:

<!-- describe what your PR is solving -->

### Related:

<!-- link to the issue(s) your PR is solving. If it doesn't exist, remove the "Related" section. -->
