### PR TITLE
Add pull request labeling rule

### DIFF
--- a/.ai-factory/RULES.md
+++ b/.ai-factory/RULES.md
@@ -5,3 +5,4 @@
 ## Rules
 
 - Never use `Illuminate\Support\Facades\Log` or add logging through Laravel facades.
+- When creating a pull request, assign exactly one label only when the change clearly matches one category: `added` for new functionality, `fix` for a functionality or other defect fix, `minor` for non-critical project structure changes, or `removed` for removed functionality or content; otherwise assign no label.


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [ ] New Feature

### Description:

Adds a project rule for assigning one PR label only when the change clearly matches `added`, `fix`, `minor`, or `removed`.

This keeps PR classification consistent while leaving unrelated or ambiguous changes unlabeled. The change affects project instructions only and has no runtime impact.

### Validation:

- `git diff --check origin/main...HEAD`