### PR TITLE
Make feed publication failure-safe across split parts

### DIFF
--- a/.ai-factory/plans/fix-failure-safe-feed-publication.md
+++ b/.ai-factory/plans/fix-failure-safe-feed-publication.md
@@ -1,0 +1,30 @@
+# Implementation Plan: Failure-Safe Feed Publication
+
+Branch: fix/failure-safe-feed-publication
+Created: 2026-07-20
+
+## Original Request
+
+implement [https://github.com/TheDragonCode/laravel-feeds/issues/161](https://github.com/TheDragonCode/laravel-feeds/issues/161)
+
+## Settings
+
+- Testing: yes
+- Logging: verbose
+- Docs: no
+
+## Tasks
+
+### Phase 1: Publication Transaction
+
+- [x] Task 1: Refactor `src/Services/FilesystemService.php` to create collision-resistant drafts inside a generation-wide staging directory, acquire a deterministic per-feed exclusive lock, back up all current outputs before commit, publish the staged target set, restore every prior output after a failed mutation, remove obsolete numeric split parts only after all new parts are ready, and clean staging drafts/backups in `finally`. Preserve `release()` compatibility. Logging: expose no Laravel facade logging; failures must retain path and operation context through exceptions, while verbose lifecycle logs remain controllable by the caller.
+
+### Phase 2: Generation Lifecycle
+
+- [x] Task 2: Update `src/Services/GeneratorService.php` and `src/Services/ExportService.php` so every split part is fully converted and closed into staging before one publication commit, an open draft is always closed after conversion failure, and last-activity/events occur only around a successful generation. Add DEBUG-only console lifecycle output for lock/staging, staged part count, commit completion, and failure context; never use `Illuminate\\Support\\Facades\\Log`. Depends on Task 1.
+
+### Phase 3: Regression Coverage
+
+- [x] Task 3: Extend `tests/Unit/Services/FilesystemServiceTest.php` and `tests/Unit/Services/ExportServiceTest.php` with coverage for unique draft paths, exclusive per-feed locks, move failure rollback, obsolete-output handling, and resource cleanup after export failure. Logging: assertions must cover contextual exceptions or DEBUG output where applicable, with no unconditional test output. Depends on Tasks 1 and 2.
+
+- [x] Task 4: Add end-to-end feed publication coverage under `tests/Feature/Feeds/` proving that a later split conversion failure preserves all old parts, regenerating three parts as one removes exactly the two obsolete parts, unrelated files remain untouched, and staging drafts/backups disappear after success and failure. Logging: exercise normal silent output and keep DEBUG diagnostics opt-in. Depends on Tasks 1, 2, and 3.

--- a/src/Services/ExportService.php
+++ b/src/Services/ExportService.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Model;
 use InvalidArgumentException;
 use Symfony\Component\Console\Helper\ProgressBar;
 
+use function is_resource;
 use function min;
 use function value;
 
@@ -92,30 +93,38 @@ class ExportService
 
     public function export(): void
     {
-        $this->feed->builder()
-            ->lazyById($this->chunk)
-            ->each(function (Model $model) {
-                $this->records++;
-                $this->left--;
+        try {
+            $this->feed->builder()
+                ->lazyById($this->chunk)
+                ->each(function (Model $model) {
+                    $this->records++;
+                    $this->left--;
 
-                $this->append(
-                    value($this->item, $model, $this->isLastItem())
-                );
+                    $this->append(
+                        value($this->item, $model, $this->isLastItem())
+                    );
 
-                $this->store();
+                    $this->store();
 
-                if ($this->left <= 0) {
-                    return false;
-                }
+                    if ($this->left <= 0) {
+                        return false;
+                    }
 
-                if ($this->maxFiles && $this->writtenFiles >= $this->maxFiles) {
-                    return false;
-                }
-            });
+                    if ($this->maxFiles && $this->writtenFiles >= $this->maxFiles) {
+                        return false;
+                    }
+                });
 
-        $this->store(true);
+            $this->store(true);
 
-        $this->progressBar?->finish();
+            $this->progressBar?->finish();
+        } finally {
+            if (is_resource($this->resource)) {
+                $this->filesystem->close($this->resource);
+            }
+
+            $this->resource = null;
+        }
     }
 
     protected function store(bool $force = false): void

--- a/src/Services/FilesystemService.php
+++ b/src/Services/FilesystemService.php
@@ -4,24 +4,43 @@ declare(strict_types=1);
 
 namespace DragonCode\LaravelFeed\Services;
 
+use Closure;
 use DragonCode\LaravelFeed\Exceptions\CloseFeedException;
 use DragonCode\LaravelFeed\Exceptions\OpenFeedException;
 use DragonCode\LaravelFeed\Exceptions\ResourceMetaException;
 use DragonCode\LaravelFeed\Exceptions\WriteFeedException;
 use Illuminate\Filesystem\Filesystem as File;
+use Illuminate\Filesystem\LockableFile;
 use Illuminate\Support\Str;
 use RuntimeException;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
 use Throwable;
 
+use function array_keys;
+use function array_reverse;
+use function basename;
+use function bin2hex;
 use function dirname;
 use function fclose;
 use function fopen;
 use function fwrite;
+use function get_class;
+use function hash;
+use function implode;
+use function is_array;
 use function is_resource;
-use function microtime;
+use function is_string;
+use function pathinfo;
+use function preg_match;
+use function preg_quote;
+use function random_bytes;
+use function realpath;
+use function sort;
+use function storage_path;
+use function str_replace;
 use function stream_get_meta_data;
 use function strlen;
+use function strtolower;
 use function substr;
 
 class FilesystemService
@@ -31,12 +50,12 @@ class FilesystemService
     ) {}
 
     /** @return resource */
-    public function createDraft(string $filename) // @pest-ignore-type
+    public function createDraft(string $filename, ?string $directory = null) // @pest-ignore-type
     {
-        $temp = $this->draftPath($filename);
+        $temp = $this->draftPath($filename, $directory);
 
         try {
-            $resource = fopen($temp, 'ab');
+            $resource = fopen($temp, 'xb');
 
             if ($resource === false) {
                 // @codeCoverageIgnoreStart
@@ -73,27 +92,85 @@ class FilesystemService
     /** @param  resource  $resource */
     public function release($resource, string $path): void // @pest-ignore-type
     {
+        $temp = null;
+
         try {
-            $temp = $this->getMetaPath($resource);
+            $temp = $this->finishDraft($resource);
 
-            $this->close($resource);
-
-            if ($this->file->exists($path)) {
-                $this->file->delete($path);
-            }
-
-            $this->file->ensureDirectoryExists(
-                dirname($path)
-            );
-
-            $this->file->move($temp, $path);
-
-            $this->cleanTemporaryDirectory($temp);
+            $this->publish($path, fn () => [$path => $temp]);
             // @codeCoverageIgnoreStart
         } catch (Throwable $e) {
+            if ($e instanceof CloseFeedException) {
+                throw $e;
+            }
+
             throw new CloseFeedException($path, $e);
+        } finally {
+            if ($temp !== null) {
+                $this->cleanTemporaryDirectory($temp);
+            }
         }
         // @codeCoverageIgnoreEnd
+    }
+
+    public function finishDraft(mixed $resource): string
+    {
+        $temp = $this->getMetaPath($resource);
+
+        $this->close($resource);
+
+        return $temp;
+    }
+
+    public function lock(string $path, Closure $callback, bool $block = true): mixed
+    {
+        $lock = new LockableFile($this->lockPath($path), 'c+');
+
+        try {
+            $lock->getExclusiveLock($block);
+
+            return $callback();
+        } finally {
+            $lock->close();
+        }
+    }
+
+    public function publish(string $path, Closure $callback): void
+    {
+        $this->lock($path, function () use ($callback, $path) {
+            $staging = $this->createStagingDirectory($path);
+            $cleanup = true;
+            $failure = null;
+
+            try {
+                $drafts = $callback($staging->path());
+
+                if (! is_array($drafts)) {
+                    throw new RuntimeException('The publication callback must return an array of staged files.');
+                }
+
+                $this->commit($path, $drafts, $staging->path(), $cleanup);
+            } catch (Throwable $e) {
+                $failure = $e;
+            }
+
+            if ($cleanup && ! $staging->delete()) {
+                $cleanupFailure = new RuntimeException("Unable to clean the feed staging directory: [{$staging->path()}].");
+
+                if ($failure !== null) {
+                    throw new RuntimeException(
+                        $failure->getMessage() . ' ' . $cleanupFailure->getMessage(),
+                        previous: $failure
+                    );
+                }
+
+                throw $cleanupFailure;
+            }
+
+            if ($failure !== null) {
+                throw $failure;
+            }
+        });
     }
 
     /** @param  resource  $resource */
@@ -115,21 +192,271 @@ class FilesystemService
         );
     }
 
-    protected function draftPath(string $filename): string
+    protected function backup(string $path, string $staging): string
     {
+        $directory = $staging . DIRECTORY_SEPARATOR . 'backups';
+
+        $this->file->ensureDirectoryExists($directory);
+
+        if (! $this->file->isDirectory($directory)) {
+            throw new RuntimeException("Unable to create the feed backup directory: [$directory].");
+        }
+
+        $backup = $directory . DIRECTORY_SEPARATOR . $this->temporaryFilename(basename($path));
+
+        if (! $this->file->move($path, $backup)) {
+            throw new RuntimeException("Unable to back up the published feed: [$path].");
+        }
+
+        return $backup;
+    }
+
+    protected function commit(string $path, array $drafts, string $staging, bool &$cleanup): void
+    {
+        $drafts   = $this->validateDrafts($path, $drafts);
+        $existing = $this->publishedPaths($path);
+        $targets  = array_keys($drafts);
+
+        $backups   = [];
+        $installed = [];
+
+        try {
+            foreach ($drafts as $target => $draft) {
+                if ($this->file->exists($target)) {
+                    $backups[$target] = $this->backup($target, $staging);
+                }
+
+                $this->file->ensureDirectoryExists(dirname($target));
+
+                if (! $this->file->move($draft, $target)) {
+                    throw new RuntimeException("Unable to publish the staged feed: [$draft] to [$target].");
+                }
+
+                $installed[] = $target;
+            }
+
+            foreach ($existing as $published) {
+                if ($this->containsPath($targets, $published) || ! $this->file->exists($published)) {
+                    continue;
+                }
+
+                $backups[$published] = $this->backup($published, $staging);
+            }
+        } catch (Throwable $e) {
+            $rollbackFailure = $this->rollback($installed, $backups);
+
+            if ($rollbackFailure !== null) {
+                $cleanup = false;
+
+                throw new CloseFeedException(
+                    $path,
+                    new RuntimeException(
+                        $e->getMessage() . ' Rollback failed: ' . $rollbackFailure->getMessage()
+                        . " Backups were preserved at: [$staging].",
+                        previous: $e
+                    )
+                );
+            }
+
+            throw new CloseFeedException($path, $e);
+        }
+    }
+
+    protected function containsPath(array $paths, string $expected): bool
+    {
+        $key = $this->pathKey($expected);
+
+        foreach ($paths as $path) {
+            if ($this->pathKey($path) === $key) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function createStagingDirectory(string $path): TemporaryDirectory
+    {
+        try {
+            $this->file->ensureDirectoryExists(dirname($path));
+
+            return (new TemporaryDirectory)
+                ->location(dirname($path))
+                ->name('.feeds_staging_' . bin2hex(random_bytes(16)))
+                ->create();
+        } catch (Throwable $e) {
+            throw new OpenFeedException($path, $e);
+        }
+    }
+
+    protected function draftPath(string $filename, ?string $directory = null): string
+    {
+        if ($directory !== null) {
+            return $directory . DIRECTORY_SEPARATOR . $this->temporaryFilename($filename);
+        }
+
         return (new TemporaryDirectory)
             ->name($this->temporaryFilename($filename))
             ->create()
-            ->path((string) microtime(true));
+            ->path($this->temporaryFilename($filename));
+    }
+
+    protected function isPublicationPath(string $path, string $publication): bool
+    {
+        if ($this->pathKey($path) === $this->pathKey($publication)) {
+            return true;
+        }
+
+        if ($this->pathKey(dirname($path)) !== $this->pathKey(dirname($publication))) {
+            return false;
+        }
+
+        return $this->matchesSplitFilename(basename($path), basename($publication));
+    }
+
+    protected function lockPath(string $path): string
+    {
+        return storage_path(
+            'framework/cache/laravel-feeds/' . hash('sha256', $this->pathKey($path)) . '.lock'
+        );
+    }
+
+    protected function matchesSplitFilename(string $filename, string $publication): bool
+    {
+        $basename  = pathinfo($publication, PATHINFO_FILENAME);
+        $extension = pathinfo($publication, PATHINFO_EXTENSION);
+        $suffix    = $extension === '' ? '' : '\\.' . preg_quote($extension, '~');
+
+        return preg_match(
+            '~^' . preg_quote($basename, '~') . '-[1-9][0-9]*' . $suffix . '$~D',
+            $filename
+        ) === 1;
+    }
+
+    protected function pathKey(string $path): string
+    {
+        $path = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $path);
+
+        $resolved = realpath($path);
+
+        if ($resolved !== false) {
+            $path = $resolved;
+        } elseif (($directory = realpath(dirname($path))) !== false) {
+            $path = $directory . DIRECTORY_SEPARATOR . basename($path);
+        }
+
+        return DIRECTORY_SEPARATOR === '\\' ? strtolower($path) : $path;
+    }
+
+    protected function publishedPaths(string $path): array
+    {
+        $paths = [];
+
+        if ($this->file->exists($path)) {
+            $paths[] = $path;
+        }
+
+        foreach ($this->file->files(dirname($path)) as $file) {
+            if ($this->matchesSplitFilename($file->getFilename(), basename($path))) {
+                $paths[] = $file->getPathname();
+            }
+        }
+
+        sort($paths, SORT_NATURAL);
+
+        return $paths;
+    }
+
+    protected function rollback(array $installed, array $backups): ?Throwable
+    {
+        $failures = [];
+
+        foreach (array_reverse($installed) as $path) {
+            try {
+                if ($this->file->exists($path) && ! $this->file->delete($path)) {
+                    throw new RuntimeException("Unable to remove the new feed during rollback: [$path].");
+                }
+            } catch (Throwable $e) {
+                $failures[] = $e;
+            }
+        }
+
+        foreach (array_reverse($backups, true) as $path => $backup) {
+            try {
+                if ($this->file->exists($path) && ! $this->file->delete($path)) {
+                    throw new RuntimeException("Unable to clear the feed path during rollback: [$path].");
+                }
+
+                if (! $this->file->move($backup, $path)) {
+                    throw new RuntimeException("Unable to restore the published feed during rollback: [$path].");
+                }
+            } catch (Throwable $e) {
+                $failures[] = $e;
+            }
+        }
+
+        if ($failures === []) {
+            return null;
+        }
+
+        $messages = [];
+
+        foreach ($failures as $failure) {
+            $messages[] = get_class($failure) . ': ' . $failure->getMessage();
+        }
+
+        return new RuntimeException(implode('; ', $messages), previous: $failures[0]);
     }
 
     protected function temporaryFilename(string $filename): string
     {
         return Str::of($filename)
             ->prepend('feeds_draft_')
-            ->append('_', microtime(true))
+            ->append('_', bin2hex(random_bytes(16)))
             ->slug('_')
             ->toString();
+    }
+
+    protected function validateDrafts(string $path, array $drafts): array
+    {
+        if ($drafts === []) {
+            throw new RuntimeException("No staged feeds were provided for publication: [$path].");
+        }
+
+        $targets   = [];
+        $sources   = [];
+        $validated = [];
+
+        foreach ($drafts as $target => $draft) {
+            if (! is_string($target) || ! is_string($draft)) {
+                throw new RuntimeException('Staged feed paths and publication targets must be strings.');
+            }
+
+            if (! $this->isPublicationPath($target, $path)) {
+                throw new RuntimeException("Invalid feed publication target: [$target].");
+            }
+
+            if (! $this->file->isFile($draft)) {
+                throw new RuntimeException("Staged feed does not exist: [$draft].");
+            }
+
+            $targetKey = $this->pathKey($target);
+            $sourceKey = $this->pathKey($draft);
+
+            if (isset($targets[$targetKey])) {
+                throw new RuntimeException("Duplicate feed publication target: [$target].");
+            }
+
+            if (isset($sources[$sourceKey])) {
+                throw new RuntimeException("Duplicate staged feed: [$draft].");
+            }
+
+            $targets[$targetKey] = true;
+            $sources[$sourceKey] = true;
+            $validated[$target]  = $draft;
+        }
+
+        return $validated;
     }
 
     /** @param  resource  $file */

--- a/src/Services/GeneratorService.php
+++ b/src/Services/GeneratorService.php
@@ -17,8 +17,10 @@ use Illuminate\Database\Eloquent\Model;
 use Throwable;
 
 use function blank;
+use function count;
 use function event;
 use function get_class;
+use function json_encode;
 
 class GeneratorService
 {
@@ -30,25 +32,70 @@ class GeneratorService
 
     public function feed(Feed $feed, ?OutputStyle $output = null): void
     {
+        $class = get_class($feed);
+        $path  = $feed->path();
+
+        $this->debug($output, 'Generation started.', [
+            'feed' => $class,
+            'path' => $path,
+        ]);
+
         try {
             $this->started($feed);
 
-            $this->export($feed, $output, $this->filesystem);
+            $this->filesystem->publish($path, function (string $staging) use ($feed, $output) {
+                $this->debug($output, 'Publication lock acquired and staging created.', [
+                    'feed'    => get_class($feed),
+                    'staging' => $staging,
+                ]);
+
+                $drafts = $this->export($feed, $output, $this->filesystem, $staging);
+
+                $this->debug($output, 'All feed parts staged.', [
+                    'feed'  => get_class($feed),
+                    'parts' => count($drafts),
+                ]);
+
+                return $drafts;
+            });
+
+            $this->debug($output, 'Publication committed.', [
+                'feed' => $class,
+                'path' => $path,
+            ]);
 
             $this->setLastActivity($feed);
 
-            $this->finished($feed, $feed->path());
+            $this->finished($feed, $path);
+
+            $this->debug($output, 'Generation finished.', [
+                'feed' => $class,
+                'path' => $path,
+            ]);
         } catch (Throwable $e) {
-            throw new FeedGenerationException(get_class($feed), $e);
+            $this->debug($output, 'Generation failed.', [
+                'feed'      => $class,
+                'path'      => $path,
+                'exception' => get_class($e),
+                'message'   => $e->getMessage(),
+            ]);
+
+            throw new FeedGenerationException($class, $e);
         }
     }
 
-    protected function export(Feed $feed, ?OutputStyle $output, FilesystemService $filesystem): void
-    {
+    protected function export(
+        Feed $feed,
+        ?OutputStyle $output,
+        FilesystemService $filesystem,
+        string $staging
+    ): array {
+        $drafts = [];
+
         (new ExportService($feed, $filesystem, $output))
             ->file(
-                create: $this->createFile($feed),
-                close : $this->closeFile($feed)
+                create: $this->createFile($feed, $staging),
+                close : $this->closeFile($feed, $drafts)
             )
             ->item(fn (Model $model, bool $last) => $this->converter($feed)->item(
                 item  : $feed->item($model),
@@ -56,29 +103,46 @@ class GeneratorService
             ))
             ->chunk($feed->chunkSize())
             ->export();
+
+        return $drafts;
     }
 
-    protected function createFile(Feed $feed): Closure
+    protected function createFile(Feed $feed, string $staging): Closure
     {
-        return function () use ($feed) {
-            $file = $this->createDraft($feed->filename());
+        return function () use ($feed, $staging) {
+            $file = $this->createDraft($feed->filename(), $staging);
 
-            $this->performHeader($file, $feed);
-            $this->performRoot($file, $feed, true);
-            $this->performInfo($file, $feed);
-            $this->performRoot($file, $feed, false);
+            try {
+                $this->performHeader($file, $feed);
+                $this->performRoot($file, $feed, true);
+                $this->performInfo($file, $feed);
+                $this->performRoot($file, $feed, false);
 
-            return $file;
+                return $file;
+            } catch (Throwable $e) {
+                $this->filesystem->close($file);
+
+                throw $e;
+            }
         };
     }
 
-    protected function closeFile(Feed $feed): Closure
+    protected function closeFile(Feed $feed, array &$drafts): Closure
     {
-        return function ($file, int $index) use ($feed) {
+        return function ($file, int $index) use ($feed, &$drafts) {
             $this->performFooter($file, $feed);
 
-            $this->release($file, $feed->path($index));
+            $drafts[$feed->path($index)] = $this->filesystem->finishDraft($file);
         };
+    }
+
+    protected function debug(?OutputStyle $output, string $message, array $context): void
+    {
+        if (! $output?->isDebug()) {
+            return;
+        }
+
+        $output->writeln('[laravel-feeds] ' . $message . ' ' . json_encode($context));
     }
 
     protected function performHeader($file, Feed $feed): void // @pest-ignore-type
@@ -130,14 +194,9 @@ class GeneratorService
         $this->filesystem->append($file, $content, $path);
     }
 
-    protected function release($file, string $path): void // @pest-ignore-type
+    protected function createDraft(string $filename, string $staging) // @pest-ignore-type
     {
-        $this->filesystem->release($file, $path);
-    }
-
-    protected function createDraft(string $filename) // @pest-ignore-type
-    {
-        return $this->filesystem->createDraft($filename);
+        return $this->filesystem->createDraft($filename, $staging);
     }
 
     protected function setLastActivity(Feed $feed): void

--- a/tests/.pest/snapshots/Feature/Feeds/PublicationSafetyTest/keeps_every_published_part_unchanged_when_a_later_split_conversion_fails.snap
+++ b/tests/.pest/snapshots/Feature/Feeds/PublicationSafetyTest/keeps_every_published_part_unchanged_when_a_later_split_conversion_fails.snap
@@ -1,0 +1,1 @@
+end of snapshots

--- a/tests/.pest/snapshots/Feature/Feeds/PublicationSafetyTest/publishes_one_part_and_removes_only_obsolete_numeric_parts.snap
+++ b/tests/.pest/snapshots/Feature/Feeds/PublicationSafetyTest/publishes_one_part_and_removes_only_obsolete_numeric_parts.snap
@@ -1,0 +1,1 @@
+end of snapshots

--- a/tests/Feature/Feeds/PublicationSafetyTest.php
+++ b/tests/Feature/Feeds/PublicationSafetyTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+use DragonCode\LaravelFeed\Enums\FeedFormatEnum;
+use DragonCode\LaravelFeed\Events\FeedFinishedEvent;
+use DragonCode\LaravelFeed\Exceptions\FeedGenerationException;
+use DragonCode\LaravelFeed\Feeds\Feed;
+use DragonCode\LaravelFeed\Feeds\Items\FeedItem;
+use DragonCode\LaravelFeed\Models\Feed as FeedModel;
+use DragonCode\LaravelFeed\Services\GeneratorService;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Event;
+use Workbench\App\Data\NewsFakeData;
+use Workbench\App\Models\News;
+
+final class PublicationSafetyFeed extends Feed
+{
+    public static int $perFile = 2;
+
+    public static ?int $failOnId = null;
+
+    protected FeedFormatEnum $format = FeedFormatEnum::JsonLines;
+
+    public function builder(): Builder
+    {
+        return News::query();
+    }
+
+    public function filename(): string
+    {
+        return 'publication-safety.jsonl';
+    }
+
+    public function item(Model $model): FeedItem
+    {
+        return new PublicationSafetyFeedItem($model);
+    }
+
+    public function perFile(): int
+    {
+        return self::$perFile;
+    }
+}
+
+final class PublicationSafetyFeedItem extends FeedItem
+{
+    public function toArray(): array
+    {
+        if ($this->model->getKey() === PublicationSafetyFeed::$failOnId) {
+            throw new RuntimeException('Later split conversion failed.');
+        }
+
+        return parent::toArray();
+    }
+}
+
+function publicationSafetySibling(Feed $feed, string $suffix): string
+{
+    $path      = $feed->path();
+    $directory = dirname($path);
+    $filename  = pathinfo($path, PATHINFO_FILENAME);
+    $extension = pathinfo($path, PATHINFO_EXTENSION);
+
+    return $directory . DIRECTORY_SEPARATOR . "$filename-$suffix.$extension";
+}
+
+function publicationSafetyArtifacts(Feed $feed): array
+{
+    $directory = dirname($feed->path()) . DIRECTORY_SEPARATOR;
+
+    return [
+        ...glob($directory . '.feeds_staging_*'),
+        ...glob($directory . '.feeds_lock_*'),
+    ];
+}
+
+function cleanupPublicationSafety(Feed $feed): void
+{
+    $filesystem = new Filesystem;
+
+    $filesystem->delete($feed->path());
+
+    foreach (range(1, 5) as $index) {
+        $filesystem->delete($feed->path($index));
+    }
+
+    $filesystem->delete(publicationSafetySibling($feed, 'copy'));
+
+    foreach (publicationSafetyArtifacts($feed) as $directory) {
+        $filesystem->deleteDirectory($directory);
+    }
+
+    $filesystem->deleteDirectory(storage_path('framework/cache/laravel-feeds'));
+}
+
+beforeEach(function () {
+    PublicationSafetyFeed::$perFile  = 2;
+    PublicationSafetyFeed::$failOnId = null;
+
+    cleanupPublicationSafety(app(PublicationSafetyFeed::class));
+});
+
+afterEach(function () {
+    cleanupPublicationSafety(app(PublicationSafetyFeed::class));
+});
+
+test('keeps every published part unchanged when a later split conversion fails', function () {
+    Event::fake();
+
+    createNews(...NewsFakeData::toArray());
+
+    $feed = app(PublicationSafetyFeed::class);
+
+    $published = [
+        $feed->path(1) => 'old-first',
+        $feed->path(2) => 'old-second',
+        $feed->path(3) => 'old-third',
+    ];
+
+    foreach ($published as $path => $content) {
+        file_put_contents($path, $content);
+    }
+
+    $record = FeedModel::create([
+        'class' => PublicationSafetyFeed::class,
+        'title' => 'Publication Safety',
+    ]);
+
+    PublicationSafetyFeed::$failOnId = News::query()->orderBy('id')->value('id') + 2;
+
+    expect(fn () => app(GeneratorService::class)->feed($feed))
+        ->toThrow(FeedGenerationException::class, 'Later split conversion failed.');
+
+    foreach ($published as $path => $content) {
+        expect(file_get_contents($path))->toBe($content);
+    }
+
+    expect($record->refresh()->last_activity)
+        ->toBeNull()
+        ->and(publicationSafetyArtifacts($feed))
+        ->toBe([]);
+
+    Event::assertNotDispatched(FeedFinishedEvent::class);
+});
+
+test('publishes one part and removes only obsolete numeric parts', function () {
+    Event::fake();
+
+    createNews(...NewsFakeData::toArray());
+
+    $feed = app(PublicationSafetyFeed::class);
+
+    FeedModel::create([
+        'class' => PublicationSafetyFeed::class,
+        'title' => 'Publication Safety',
+    ]);
+
+    PublicationSafetyFeed::$perFile = 1;
+
+    app(GeneratorService::class)->feed($feed);
+
+    expect($feed->path(1))
+        ->toBeFile()
+        ->and($feed->path(2))
+        ->toBeFile()
+        ->and($feed->path(3))
+        ->toBeFile();
+
+    $unrelated = publicationSafetySibling($feed, 'copy');
+
+    file_put_contents($unrelated, 'unrelated');
+
+    News::query()->where('id', '>', News::query()->min('id'))->delete();
+
+    PublicationSafetyFeed::$perFile = 0;
+
+    app(GeneratorService::class)->feed($feed);
+
+    expect($feed->path())
+        ->toBeFile()
+        ->and($feed->path(1))
+        ->not->toBeFile()
+        ->and($feed->path(2))
+        ->not->toBeFile()
+        ->and($feed->path(3))
+        ->not->toBeFile()
+        ->and(file_get_contents($unrelated))
+        ->toBe('unrelated')
+        ->and(publicationSafetyArtifacts($feed))
+        ->toBe([]);
+});

--- a/tests/Unit/Services/ExportServiceTest.php
+++ b/tests/Unit/Services/ExportServiceTest.php
@@ -161,3 +161,36 @@ test('rejects a non-positive chunk size', function (int $chunk) {
     expect(fn () => $service->chunk($chunk))
         ->toThrow(InvalidArgumentException::class);
 })->with([0, -1]);
+
+test('closes the active resource when export fails', function () {
+    $model = mock(Model::class);
+
+    $builder = mock(Builder::class);
+    $builder->shouldReceive('count')->once()->andReturn(1);
+    $builder->shouldReceive('lazyById')->once()->with(1)->andReturn(LazyCollection::make([$model]));
+
+    $feed = mock(Feed::class);
+    $feed->shouldReceive('perFile')->once()->andReturn(0);
+    $feed->shouldReceive('maxFiles')->once()->andReturn(0);
+    $feed->shouldReceive('builder')->twice()->andReturn($builder);
+    $feed->shouldReceive('path')->once()->andReturn('feed.json');
+
+    $resource = fopen('php://memory', 'wb');
+
+    $filesystem = mock(FilesystemService::class);
+    $filesystem->shouldReceive('append')->once()->andThrow(new RuntimeException('Write failed.'));
+    $filesystem->shouldReceive('close')->once()->with($resource)->andReturnUsing(fclose(...));
+
+    $service = (new ExportService($feed, $filesystem, null))
+        ->file(
+            create: fn () => $resource,
+            close : fn () => null
+        )
+        ->item(fn () => 'item')
+        ->chunk(1);
+
+    expect(fn () => $service->export())
+        ->toThrow(RuntimeException::class, 'Write failed.')
+        ->and(is_resource($resource))
+        ->toBeFalse();
+});

--- a/tests/Unit/Services/FilesystemServiceTest.php
+++ b/tests/Unit/Services/FilesystemServiceTest.php
@@ -2,8 +2,10 @@
 
 declare(strict_types=1);
 
+use DragonCode\LaravelFeed\Exceptions\CloseFeedException;
 use DragonCode\LaravelFeed\Exceptions\WriteFeedException;
 use DragonCode\LaravelFeed\Services\FilesystemService;
+use Illuminate\Contracts\Filesystem\LockTimeoutException;
 use Illuminate\Filesystem\Filesystem;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
 
@@ -47,12 +49,35 @@ final class ControlledWriteStream
     }
 }
 
+final class ControlledMoveFilesystem extends Filesystem
+{
+    protected array $moveFailures = [];
+
+    public function failNextMoveTo(string $path): void
+    {
+        $this->moveFailures[$path] = true;
+    }
+
+    public function move($path, $target)
+    {
+        if (isset($this->moveFailures[$target])) {
+            unset($this->moveFailures[$target]);
+
+            return false;
+        }
+
+        return parent::move($path, $target);
+    }
+}
+
 beforeEach(function () {
     stream_wrapper_register('controlled-write', ControlledWriteStream::class);
 });
 
 afterEach(function () {
     stream_wrapper_unregister('controlled-write');
+
+    (new Filesystem)->deleteDirectory(storage_path('framework/cache/laravel-feeds'));
 });
 
 test('writes all bytes after partial stream writes', function () {
@@ -110,5 +135,147 @@ test('treats empty content as a no-op', function () {
             ->toBe('');
     } finally {
         fclose($resource);
+    }
+});
+
+test('creates collision-resistant drafts and cleans the staging directory', function () {
+    $directory = (new TemporaryDirectory)->create();
+    $path      = $directory->path('feed.json');
+    $drafts    = [];
+
+    try {
+        (new FilesystemService(new Filesystem))->publish($path, function (string $staging) use (&$drafts, $path) {
+            $service = new FilesystemService(new Filesystem);
+            $first   = $service->createDraft('feed.json', $staging);
+            $second  = $service->createDraft('feed.json', $staging);
+
+            $drafts[] = $service->finishDraft($first);
+            $drafts[] = $service->finishDraft($second);
+
+            return [$path => $drafts[0]];
+        });
+
+        expect($drafts[0])
+            ->not->toBe($drafts[1])
+            ->and($path)
+            ->toBeFile()
+            ->and(glob($directory->path() . DIRECTORY_SEPARATOR . '.feeds_staging_*'))
+            ->toBe([]);
+    } finally {
+        $directory->delete();
+    }
+});
+
+test('prevents overlapping publication for the same feed', function () {
+    $directory = (new TemporaryDirectory)->create();
+    $path      = $directory->path('feed.json');
+    $service   = new FilesystemService(new Filesystem);
+
+    try {
+        $service->lock($path, function () use ($path, $service) {
+            expect(fn () => $service->lock($path, fn () => null, false))
+                ->toThrow(LockTimeoutException::class);
+        });
+    } finally {
+        $directory->delete();
+    }
+});
+
+test('restores every published part when a staged move fails', function () {
+    $directory   = (new TemporaryDirectory)->create();
+    $publication = $directory->path('feed.json');
+    $first       = $directory->path('feed-1.json');
+    $second      = $directory->path('feed-2.json');
+    $file        = new ControlledMoveFilesystem;
+    $service     = new FilesystemService($file);
+
+    file_put_contents($first, 'old-first');
+    file_put_contents($second, 'old-second');
+
+    $file->failNextMoveTo($second);
+
+    try {
+        expect(fn () => $service->publish($publication, function (string $staging) use ($first, $second, $service) {
+            $firstDraft = $service->createDraft('feed.json', $staging);
+            $service->append($firstDraft, 'new-first', $first);
+
+            $secondDraft = $service->createDraft('feed.json', $staging);
+            $service->append($secondDraft, 'new-second', $second);
+
+            return [
+                $first  => $service->finishDraft($firstDraft),
+                $second => $service->finishDraft($secondDraft),
+            ];
+        }))
+            ->toThrow(CloseFeedException::class, 'Unable to publish the staged feed:');
+
+        expect(file_get_contents($first))
+            ->toBe('old-first')
+            ->and(file_get_contents($second))
+            ->toBe('old-second')
+            ->and(glob($directory->path() . DIRECTORY_SEPARATOR . '.feeds_staging_*'))
+            ->toBe([]);
+    } finally {
+        $directory->delete();
+    }
+});
+
+test('release restores the published feed and cleans its draft when move fails', function () {
+    $directory   = (new TemporaryDirectory)->create();
+    $publication = $directory->path('feed.json');
+    $file        = new ControlledMoveFilesystem;
+    $service     = new FilesystemService($file);
+    $draft       = $service->createDraft('feed.json', $directory->path('drafts'));
+    $draftPath   = stream_get_meta_data($draft)['uri'];
+
+    file_put_contents($publication, 'old');
+
+    $service->append($draft, 'new', $publication);
+    $file->failNextMoveTo($publication);
+
+    try {
+        expect(fn () => $service->release($draft, $publication))
+            ->toThrow(CloseFeedException::class, 'Unable to publish the staged feed:')
+            ->and(file_get_contents($publication))
+            ->toBe('old')
+            ->and(dirname($draftPath))
+            ->not->toBeDirectory();
+    } finally {
+        $directory->delete();
+    }
+});
+
+test('removes only obsolete numeric split parts after a successful commit', function () {
+    $directory   = (new TemporaryDirectory)->create();
+    $publication = $directory->path('feed.json');
+    $unrelated   = $directory->path('feed-copy.json');
+    $service     = new FilesystemService(new Filesystem);
+
+    foreach (range(1, 3) as $index) {
+        file_put_contents($directory->path("feed-$index.json"), "old-$index");
+    }
+
+    file_put_contents($unrelated, 'unrelated');
+
+    try {
+        $service->publish($publication, function (string $staging) use ($publication, $service) {
+            $draft = $service->createDraft('feed.json', $staging);
+            $service->append($draft, 'new', $publication);
+
+            return [$publication => $service->finishDraft($draft)];
+        });
+
+        expect(file_get_contents($publication))
+            ->toBe('new')
+            ->and($directory->path('feed-1.json'))
+            ->not->toBeFile()
+            ->and($directory->path('feed-2.json'))
+            ->not->toBeFile()
+            ->and($directory->path('feed-3.json'))
+            ->not->toBeFile()
+            ->and(file_get_contents($unrelated))
+            ->toBe('unrelated');
+    } finally {
+        $directory->delete();
     }
 });


### PR DESCRIPTION
## Summary

- Stage every split part before touching published output.
- Serialize generation with a per-feed file lock.
- Commit with backups and rollback, then remove obsolete numeric parts.
- Close open resources and clean staging files after success or failure.
- Add regression coverage for conversion failures, move failures, shrinking output, and locking.

## Root cause

Split parts were released while generation was still running, and `release()` removed the current destination before moving the draft. A later conversion or move failure could leave mixed, missing, or stale output.

## Impact

Failed generations preserve the previously published feed. Concurrent generators for the same feed cannot interleave publication. Existing feed paths and split numbering remain compatible.

## Validation

- `composer test` — 215 tests, 1233 assertions
- `composer test:type` — 99.6%
- Pint — passed

Closes #161