### PR TITLE
Fix XML attribute escaping and root serialization

### DIFF
--- a/src/Converters/XmlConverter.php
+++ b/src/Converters/XmlConverter.php
@@ -6,17 +6,22 @@ namespace DragonCode\LaravelFeed\Converters;
 
 use DOMDocument;
 use DOMNode;
-use DragonCode\LaravelFeed\Data\ElementData;
+use DragonCode\LaravelFeed\Exceptions\InvalidXmlCDataException;
+use DragonCode\LaravelFeed\Exceptions\InvalidXmlFragmentException;
 use DragonCode\LaravelFeed\Feeds\Feed;
 use DragonCode\LaravelFeed\Feeds\Items\FeedItem;
 use DragonCode\LaravelFeed\Services\TransformerService;
 use DragonCode\LaravelFeed\Transformers\SpecialCharsTransformer;
 use Illuminate\Container\Attributes\Config;
 use Illuminate\Support\Str;
+use Throwable;
 
-use function collect;
+use function array_slice;
+use function count;
 use function is_array;
-use function sprintf;
+use function libxml_clear_errors;
+use function libxml_get_errors;
+use function libxml_use_internal_errors;
 use function str_replace;
 use function str_starts_with;
 use function trim;
@@ -64,9 +69,19 @@ class XmlConverter extends Converter
 
     public function root(Feed $feed): string
     {
-        return ! empty($feed->root()->attributes)
-            ? sprintf("<%s %s>\n\n", $feed->root()->name, $this->rootAttributes($feed->root()))
-            : sprintf("<%s>\n\n", $feed->root()->name);
+        $root = $feed->root();
+
+        if (! $root->name) {
+            return '';
+        }
+
+        $element = $this->createElement($root->name);
+
+        if ($root->attributes) {
+            $this->setAttributes($element, $root->attributes);
+        }
+
+        return Str::replaceEnd('/>', ">\n\n", $this->encode($element));
     }
 
     public function item(FeedItem $item, bool $isLast): string
@@ -141,7 +156,11 @@ class XmlConverter extends Converter
 
     protected function createElement(string $name, mixed $value = ''): DOMNode
     {
-        return $this->document->createElement($name, (string) $this->transformValue($value));
+        $element = $this->document->createElement($name);
+
+        $this->appendText($element, $value);
+
+        return $element;
     }
 
     protected function setAttributes(DOMNode $element, array $attributes): void
@@ -153,15 +172,43 @@ class XmlConverter extends Converter
 
     protected function setCData(DOMNode $element, string $value): void
     {
-        $element->appendChild(
-            $this->document->createCDATASection($value)
-        );
+        try {
+            $section = $this->document->createCDATASection($value);
+        } catch (Throwable $exception) {
+            throw new InvalidXmlCDataException($exception);
+        }
+
+        if ($section === false) {
+            throw new InvalidXmlCDataException;
+        }
+
+        $element->appendChild($section);
     }
 
     protected function setMixed(DOMNode $element, string $value): void
     {
-        $fragment = $this->document->createDocumentFragment();
-        $fragment->appendXML($value);
+        $fragment       = $this->document->createDocumentFragment();
+        $internalErrors = libxml_use_internal_errors(true);
+        $errorCount     = count(libxml_get_errors());
+        $reason         = null;
+
+        try {
+            $appended = $fragment->appendXML($value);
+            $errors   = array_slice(libxml_get_errors(), $errorCount);
+            $reason   = isset($errors[0]) ? trim($errors[0]->message) : null;
+        } catch (Throwable $exception) {
+            throw new InvalidXmlFragmentException(previous: $exception);
+        } finally {
+            if (! $internalErrors) {
+                libxml_clear_errors();
+            }
+
+            libxml_use_internal_errors($internalErrors);
+        }
+
+        if (! $appended) {
+            throw new InvalidXmlFragmentException($reason);
+        }
 
         $element->appendChild($fragment);
     }
@@ -188,14 +235,24 @@ class XmlConverter extends Converter
 
     protected function setRaw(DOMNode $parent, mixed $value): void
     {
-        $parent->nodeValue = (string) $this->transformValue($value);
+        while ($parent->firstChild) {
+            $parent->removeChild($parent->firstChild);
+        }
+
+        $this->appendText($parent, $value);
     }
 
-    protected function rootAttributes(ElementData $item): string
+    protected function appendText(DOMNode $parent, mixed $value): void
     {
-        return collect($item->attributes)
-            ->map(fn (mixed $value, int|string $key) => sprintf('%s="%s"', $key, $value))
-            ->implode(' ');
+        $value = (string) $this->transformValue($value);
+
+        if ($value === '') {
+            return;
+        }
+
+        $parent->appendChild(
+            $this->document->createTextNode($value)
+        );
     }
 
     protected function encode(DOMNode $item): string

--- a/src/Exceptions/InvalidXmlCDataException.php
+++ b/src/Exceptions/InvalidXmlCDataException.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DragonCode\LaravelFeed\Exceptions;
+
+use Throwable;
+use UnexpectedValueException;
+
+class InvalidXmlCDataException extends UnexpectedValueException
+{
+    public function __construct(?Throwable $previous = null)
+    {
+        parent::__construct(
+            'Unable to create an XML CDATA section for the [@cdata] directive.',
+            previous: $previous
+        );
+    }
+}

--- a/src/Exceptions/InvalidXmlFragmentException.php
+++ b/src/Exceptions/InvalidXmlFragmentException.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DragonCode\LaravelFeed\Exceptions;
+
+use Throwable;
+use UnexpectedValueException;
+
+class InvalidXmlFragmentException extends UnexpectedValueException
+{
+    public function __construct(?string $reason = null, ?Throwable $previous = null)
+    {
+        $message = 'Invalid XML fragment supplied to the [@mixed] directive.';
+
+        if ($reason) {
+            $message .= ' ' . $reason;
+        }
+
+        parent::__construct($message, previous: $previous);
+    }
+}

--- a/src/Transformers/SpecialCharsTransformer.php
+++ b/src/Transformers/SpecialCharsTransformer.php
@@ -16,7 +16,7 @@ class SpecialCharsTransformer implements Transformer
     public function transform(mixed $value): string
     {
         return $this->removeControlCharacters(
-            htmlspecialchars((string) $value)
+            (string) $value
         );
     }
 

--- a/tests/Expectations.php
+++ b/tests/Expectations.php
@@ -115,11 +115,38 @@ function parseCsv(string $content): array
     }
 }
 
-expect()->extend('toBeRss', function () {
-    // expect($this->value)->toContain('<rss version="2.0"');
-    // expect($this->value)->toContain('<channel>');
-    // expect($this->value)->toContain('</channel>');
-    // expect($this->value)->toContain('</rss>');
+expect()->extend('toBeXml', function () {
+    parseXmlDocument($this->value);
 
     return $this;
 });
+
+expect()->extend('toBeRss', function () {
+    $document = parseXmlDocument($this->value);
+
+    expect($document->documentElement?->nodeName)->toBe('rss');
+
+    return $this;
+});
+
+function parseXmlDocument(string $content): DOMDocument
+{
+    $document       = new DOMDocument;
+    $internalErrors = libxml_use_internal_errors(true);
+
+    try {
+        $loaded = $document->loadXML($content, LIBXML_NONET);
+        $error  = libxml_get_last_error();
+    } finally {
+        libxml_clear_errors();
+        libxml_use_internal_errors($internalErrors);
+    }
+
+    if (! $loaded) {
+        $reason = $error ? trim($error->message) : 'Unknown parsing error.';
+
+        throw new RuntimeException("Invalid XML: $reason");
+    }
+
+    return $document;
+}

--- a/tests/Helpers/expects.php
+++ b/tests/Helpers/expects.php
@@ -7,11 +7,12 @@ use DragonCode\LaravelFeed\Enums\FeedFormatEnum;
 
 use function Pest\Laravel\artisan;
 
-function expectFeedSnapshot(string $class, FeedFormatEnum $format = FeedFormatEnum::Xml, array $indexes = ['']): void
+function expectFeedSnapshot(string $class, ?FeedFormatEnum $format = null, array $indexes = ['']): void
 {
     $feed = findFeed($class);
 
     $instance = app($feed->class);
+    $format ??= $instance->format();
 
     artisan(FeedGenerateCommand::class, [
         'feed' => $feed->id,
@@ -29,7 +30,7 @@ function expectFeedSnapshot(string $class, FeedFormatEnum $format = FeedFormatEn
             FeedFormatEnum::JsonLines => expect($content)->toBeJsonLines(),
             FeedFormatEnum::Csv       => expect($content)->toBeCsv(),
             FeedFormatEnum::Rss       => expect($content)->toBeRss(),
-            default                   => null
+            FeedFormatEnum::Xml       => expect($content)->toBeXml(),
         };
     }
 }

--- a/tests/Unit/Converters/XmlConverterTest.php
+++ b/tests/Unit/Converters/XmlConverterTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+use DragonCode\LaravelFeed\Converters\XmlConverter;
+use DragonCode\LaravelFeed\Data\ElementData;
+use DragonCode\LaravelFeed\Exceptions\InvalidXmlCDataException;
+use DragonCode\LaravelFeed\Exceptions\InvalidXmlFragmentException;
+use DragonCode\LaravelFeed\Feeds\Feed;
+use DragonCode\LaravelFeed\Feeds\Items\FeedItem;
+
+test('round trips text and item attributes through DOM', function () {
+    $value = 'A & B "double" \'single\' <tag> > tail';
+    $cdata = $value . ' ]]> cdata';
+
+    $item = mock(FeedItem::class);
+    $item->shouldReceive('name')->once()->andReturn('item');
+    $item->shouldReceive('attributes')->once()->andReturn(['symbols' => $value]);
+    $item->shouldReceive('toArray')->once()->andReturn([
+        'text'  => $value,
+        'value' => ['discarded' => 'content', '@value' => $value],
+        'cdata' => ['@cdata' => $cdata],
+        'mixed' => ['@mixed' => '<strong>A &amp; B</strong>'],
+    ]);
+
+    $content  = app(XmlConverter::class)->item($item, true);
+    $document = parseXmlDocument($content);
+    $root     = $document->documentElement;
+
+    expect($root?->getAttribute('symbols'))
+        ->toBe($value)
+        ->and($root?->getElementsByTagName('text')->item(0)?->textContent)
+        ->toBe($value)
+        ->and($root?->getElementsByTagName('value')->item(0)?->textContent)
+        ->toBe($value)
+        ->and($root?->getElementsByTagName('cdata')->item(0)?->textContent)
+        ->toBe($cdata)
+        ->and($root?->getElementsByTagName('mixed')->item(0)?->firstElementChild?->nodeName)
+        ->toBe('strong')
+        ->and($content)
+        ->not->toContain('&amp;amp;');
+});
+
+test('round trips root attributes through DOM', function () {
+    $value = 'A & B "double" \'single\' <tag> > tail';
+
+    $feed = mock(Feed::class);
+    $feed->shouldReceive('root')->once()->andReturn(
+        new ElementData('feed', ['symbols' => $value])
+    );
+
+    $content  = app(XmlConverter::class)->root($feed) . '</feed>';
+    $document = parseXmlDocument($content);
+
+    expect($document->documentElement?->getAttribute('symbols'))
+        ->toBe($value)
+        ->and($content)
+        ->toContain('&amp;')
+        ->toContain('&quot;')
+        ->toContain('&lt;')
+        ->not->toContain('&amp;amp;');
+});
+
+test('omits an empty root element', function () {
+    $feed = mock(Feed::class);
+    $feed->shouldReceive('root')->once()->andReturn(new ElementData);
+
+    expect(app(XmlConverter::class)->root($feed))->toBe('');
+});
+
+test('rejects invalid mixed XML fragments', function () {
+    $item = mock(FeedItem::class);
+    $item->shouldReceive('name')->once()->andReturn('item');
+    $item->shouldReceive('attributes')->once()->andReturn([]);
+    $item->shouldReceive('toArray')->once()->andReturn([
+        'content' => ['@mixed' => '<broken>'],
+    ]);
+
+    expect(fn () => app(XmlConverter::class)->item($item, true))
+        ->toThrow(
+            InvalidXmlFragmentException::class,
+            'Invalid XML fragment supplied to the [@mixed] directive.'
+        );
+});
+
+test('rejects CDATA creation failures', function () {
+    $converter = app(XmlConverter::class);
+    $document  = new class ('1.0', 'UTF-8') extends DOMDocument {
+        public function createCDATASection(string $data): DOMCdataSection|false
+        {
+            return false;
+        }
+    };
+
+    (new ReflectionProperty(XmlConverter::class, 'document'))->setValue($converter, $document);
+
+    $item = mock(FeedItem::class);
+    $item->shouldReceive('name')->once()->andReturn('item');
+    $item->shouldReceive('attributes')->once()->andReturn([]);
+    $item->shouldReceive('toArray')->once()->andReturn([
+        'content' => ['@cdata' => 'value'],
+    ]);
+
+    expect(fn () => $converter->item($item, true))
+        ->toThrow(
+            InvalidXmlCDataException::class,
+            'Unable to create an XML CDATA section for the [@cdata] directive.'
+        );
+});
+
+test('wraps CDATA creation exceptions', function () {
+    $converter = app(XmlConverter::class);
+    $document  = new class ('1.0', 'UTF-8') extends DOMDocument {
+        public function createCDATASection(string $data): DOMCdataSection|false
+        {
+            throw new DOMException('CDATA failure.');
+        }
+    };
+
+    (new ReflectionProperty(XmlConverter::class, 'document'))->setValue($converter, $document);
+
+    $item = mock(FeedItem::class);
+    $item->shouldReceive('name')->once()->andReturn('item');
+    $item->shouldReceive('attributes')->once()->andReturn([]);
+    $item->shouldReceive('toArray')->once()->andReturn([
+        'content' => ['@cdata' => 'value'],
+    ]);
+
+    $thrown = null;
+
+    try {
+        $converter->item($item, true);
+    } catch (InvalidXmlCDataException $exception) {
+        $thrown = $exception;
+    }
+
+    expect($thrown)
+        ->toBeInstanceOf(InvalidXmlCDataException::class)
+        ->and($thrown?->getPrevious())
+        ->toBeInstanceOf(DOMException::class)
+        ->and($thrown?->getPrevious()?->getMessage())
+        ->toBe('CDATA failure.');
+});
+
+test('wraps mixed fragment creation exceptions', function () {
+    $converter = app(XmlConverter::class);
+    $document  = new class ('1.0', 'UTF-8') extends DOMDocument {
+        public function createDocumentFragment(): DOMDocumentFragment
+        {
+            return new class extends DOMDocumentFragment {
+                public function appendXML(string $data): bool
+                {
+                    throw new DOMException('Fragment failure.');
+                }
+            };
+        }
+    };
+
+    (new ReflectionProperty(XmlConverter::class, 'document'))->setValue($converter, $document);
+
+    $item = mock(FeedItem::class);
+    $item->shouldReceive('name')->once()->andReturn('item');
+    $item->shouldReceive('attributes')->once()->andReturn([]);
+    $item->shouldReceive('toArray')->once()->andReturn([
+        'content' => ['@mixed' => '<value/>'],
+    ]);
+
+    $thrown = null;
+
+    try {
+        $converter->item($item, true);
+    } catch (InvalidXmlFragmentException $exception) {
+        $thrown = $exception;
+    }
+
+    expect($thrown)
+        ->toBeInstanceOf(InvalidXmlFragmentException::class)
+        ->and($thrown?->getPrevious())
+        ->toBeInstanceOf(DOMException::class)
+        ->and($thrown?->getPrevious()?->getMessage())
+        ->toBe('Fragment failure.');
+});

--- a/tests/Unit/Transformers/SpecialCharTest.php
+++ b/tests/Unit/Transformers/SpecialCharTest.php
@@ -10,12 +10,12 @@ test('allows any scalar or null value', function (mixed $value) {
     expect($transformer->allow($value))->toBeTrue();
 })->with('special chars allow');
 
-test('escapes HTML special characters', function () {
+test('preserves XML special characters', function () {
     $transformer = new SpecialCharsTransformer;
 
     $value = '<b>Tom & "Jerry"\'</b>';
 
-    expect($transformer->transform($value))->toBe('&lt;b&gt;Tom &amp; &quot;Jerry&quot;&#039;&lt;/b&gt;');
+    expect($transformer->transform($value))->toBe($value);
 });
 
 test('removes ASCII control characters', function () {
@@ -26,10 +26,10 @@ test('removes ASCII control characters', function () {
     expect($transformer->transform($value))->toBe('Hello World!');
 });
 
-test('preserves multibyte characters and encodes HTML brackets', function () {
+test('preserves multibyte characters and XML brackets', function () {
     $transformer = new SpecialCharsTransformer;
 
     $value = 'Привет, мир 😀 <tag>';
 
-    expect($transformer->transform($value))->toBe('Привет, мир 😀 &lt;tag&gt;');
+    expect($transformer->transform($value))->toBe($value);
 });


### PR DESCRIPTION
## Summary

- let DOM escape scalar text, item attributes, and root attributes exactly once
- keep raw XML limited to `@mixed` and raise domain exceptions for invalid fragments and CDATA failures
- parse generated XML and RSS output and add round-trip regression coverage

## Root cause

XML values were HTML-escaped before being passed to DOM APIs, which double-escaped item attributes. Root attributes bypassed DOM entirely and were interpolated into the opening tag without XML escaping.

## Validation

- `XDEBUG_MODE=coverage composer test:coverage`: 230 tests passed, 1296 assertions, 95.5% coverage
- `composer test:type`: 99.6% type coverage
- targeted Pint check for changed files: passed
- repository-wide Pint still reports unrelated baseline formatting and line-ending issues

Fixes #163