### PR TITLE
fix(events): expose published split-feed paths

### DIFF
--- a/docs/topics/events.topic
+++ b/docs/topics/events.topic
@@ -21,7 +21,29 @@
             The <code>FeedStartingEvent</code> is dispatched immediately before the draft file is created.
         </def>
         <def title="DragonCode\LaravelFeed\Events\FeedFinishedEvent">
-            The <code>FeedFinishedEvent</code> is dispatched right after the feed file generation has completed.
+            The <code>FeedFinishedEvent</code> is dispatched after every generated file has been published successfully.
+            A failed generation does not dispatch this event.
         </def>
     </deflist>
+
+    <chapter title="Finished event contract" id="finished_event_contract">
+        <p>
+            The finished event exposes these public properties:
+        </p>
+
+        <list>
+            <li><code>$feed</code> contains the generated feed class.</li>
+            <li><code>$paths</code> contains every published file path in output order.</li>
+            <li>
+                <code>$path</code> remains available for backward compatibility and contains the first published path.
+                Use <code>$paths</code> when a feed can be split across files.
+            </li>
+        </list>
+
+        <p>
+            <code>GeneratorService::feed()</code> returns a <code>GenerationResultData</code> object.
+            Its <code>$paths</code> property contains the same ordered paths, and its <code>$records</code> property maps
+            each path to the number of records written to that file.
+        </p>
+    </chapter>
 </topic>

--- a/src/Data/GenerationResultData.php
+++ b/src/Data/GenerationResultData.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DragonCode\LaravelFeed\Data;
+
+readonly class GenerationResultData
+{
+    public function __construct(
+        public array $paths,
+        public array $records,
+    ) {}
+}

--- a/src/Events/FeedFinishedEvent.php
+++ b/src/Events/FeedFinishedEvent.php
@@ -6,6 +6,8 @@ namespace DragonCode\LaravelFeed\Events;
 
 use DragonCode\LaravelFeed\Feeds\Feed;
 
+use function array_values;
+
 class FeedFinishedEvent
 {
     /**
@@ -18,5 +20,9 @@ class FeedFinishedEvent
     public function __construct(
         public string $feed,
         public string $path,
-    ) {}
+        public array $paths = [],
+    ) {
+        $this->paths = array_values($this->paths === [] ? [$this->path] : $this->paths);
+        $this->path  = $this->paths[0];
+    }
 }

--- a/src/Services/ExportService.php
+++ b/src/Services/ExportService.php
@@ -145,8 +145,8 @@ class ExportService
         }
 
         if ($force || $whenRecords) {
-            $this->records = 0;
             $this->releaseFile();
+            $this->records = 0;
         }
     }
 
@@ -172,7 +172,7 @@ class ExportService
             return;
         }
 
-        value($this->closeFile, $this->resource, $this->fileIndex);
+        value($this->closeFile, $this->resource, $this->fileIndex, $this->records);
 
         $this->resource = null;
 

--- a/src/Services/GeneratorService.php
+++ b/src/Services/GeneratorService.php
@@ -6,6 +6,7 @@ namespace DragonCode\LaravelFeed\Services;
 
 use Closure;
 use DragonCode\LaravelFeed\Converters\Converter;
+use DragonCode\LaravelFeed\Data\GenerationResultData;
 use DragonCode\LaravelFeed\Events\FeedFinishedEvent;
 use DragonCode\LaravelFeed\Events\FeedStartingEvent;
 use DragonCode\LaravelFeed\Exceptions\FeedGenerationException;
@@ -14,8 +15,10 @@ use DragonCode\LaravelFeed\Helpers\ConverterHelper;
 use DragonCode\LaravelFeed\Queries\FeedQuery;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Database\Eloquent\Model;
+use RuntimeException;
 use Throwable;
 
+use function array_keys;
 use function blank;
 use function count;
 use function event;
@@ -30,7 +33,7 @@ class GeneratorService
         protected FeedQuery $query,
     ) {}
 
-    public function feed(Feed $feed, ?OutputStyle $output = null): void
+    public function feed(Feed $feed, ?OutputStyle $output = null): GenerationResultData
     {
         $class = get_class($feed);
         $path  = $feed->path();
@@ -43,35 +46,47 @@ class GeneratorService
         try {
             $this->started($feed);
 
-            $this->filesystem->publish($path, function (string $staging) use ($feed, $output) {
+            $result = null;
+
+            $this->filesystem->publish($path, function (string $staging) use ($feed, $output, &$result) {
                 $this->debug($output, 'Publication lock acquired and staging created.', [
                     'feed'    => get_class($feed),
                     'staging' => $staging,
                 ]);
 
-                $drafts = $this->export($feed, $output, $this->filesystem, $staging);
+                $drafts = [];
+                $result = $this->export($feed, $output, $this->filesystem, $staging, $drafts);
 
                 $this->debug($output, 'All feed parts staged.', [
-                    'feed'  => get_class($feed),
-                    'parts' => count($drafts),
+                    'feed'    => get_class($feed),
+                    'parts'   => count($result->paths),
+                    'paths'   => $result->paths,
+                    'records' => $result->records,
                 ]);
 
                 return $drafts;
             });
 
+            if (! $result instanceof GenerationResultData) {
+                throw new RuntimeException('Feed generation did not produce a result.');
+            }
+
             $this->debug($output, 'Publication committed.', [
-                'feed' => $class,
-                'path' => $path,
+                'feed'  => $class,
+                'paths' => $result->paths,
             ]);
 
             $this->setLastActivity($feed);
 
-            $this->finished($feed, $path);
+            $this->finished($feed, $result);
 
             $this->debug($output, 'Generation finished.', [
-                'feed' => $class,
-                'path' => $path,
+                'feed'    => $class,
+                'paths'   => $result->paths,
+                'records' => $result->records,
             ]);
+
+            return $result;
         } catch (Throwable $e) {
             $this->debug($output, 'Generation failed.', [
                 'feed'      => $class,
@@ -88,15 +103,16 @@ class GeneratorService
         Feed $feed,
         ?OutputStyle $output,
         FilesystemService $filesystem,
-        string $staging
-    ): array {
-        $drafts    = [];
+        string $staging,
+        array &$drafts,
+    ): GenerationResultData {
+        $records   = [];
         $converter = $this->converter($feed);
 
         (new ExportService($feed, $filesystem, $output))
             ->file(
                 create: $this->createFile($feed, $staging, $converter),
-                close : $this->closeFile($feed, $drafts, $converter)
+                close : $this->closeFile($feed, $drafts, $records, $converter)
             )
             ->item(fn (Model $model, bool $last) => $converter->item(
                 item  : $feed->item($model),
@@ -106,7 +122,10 @@ class GeneratorService
             ->chunk($feed->chunkSize())
             ->export();
 
-        return $drafts;
+        return new GenerationResultData(
+            paths  : array_keys($drafts),
+            records: $records,
+        );
     }
 
     protected function createFile(Feed $feed, string $staging, Converter $converter): Closure
@@ -129,12 +148,15 @@ class GeneratorService
         };
     }
 
-    protected function closeFile(Feed $feed, array &$drafts, Converter $converter): Closure
+    protected function closeFile(Feed $feed, array &$drafts, array &$records, Converter $converter): Closure
     {
-        return function ($file, int $index) use ($feed, &$drafts, $converter) {
+        return function ($file, int $index, int $count) use ($feed, &$drafts, &$records, $converter) {
             $this->performFooter($file, $feed, $converter);
 
-            $drafts[$feed->path($index)] = $this->filesystem->finishDraft($file);
+            $path = $feed->path($index);
+
+            $drafts[$path]  = $this->filesystem->finishDraft($file);
+            $records[$path] = $count;
         };
     }
 
@@ -220,8 +242,8 @@ class GeneratorService
         event(new FeedStartingEvent(get_class($feed)));
     }
 
-    protected function finished(Feed $feed, string $path): void
+    protected function finished(Feed $feed, GenerationResultData $result): void
     {
-        event(new FeedFinishedEvent(get_class($feed), $path));
+        event(new FeedFinishedEvent(get_class($feed), $result->paths[0], $result->paths));
     }
 }

--- a/tests/.pest/snapshots/Feature/Events/SuccessTest/keeps_the_legacy_finished_event_path_compatible.snap
+++ b/tests/.pest/snapshots/Feature/Events/SuccessTest/keeps_the_legacy_finished_event_path_compatible.snap
@@ -1,0 +1,1 @@
+end of snapshots

--- a/tests/.pest/snapshots/Feature/Events/SuccessTest/reports_every_published_path_and_its_record_count_with_data_set__dataset__single_file__.snap
+++ b/tests/.pest/snapshots/Feature/Events/SuccessTest/reports_every_published_path_and_its_record_count_with_data_set__dataset__single_file__.snap
@@ -1,0 +1,1 @@
+end of snapshots

--- a/tests/.pest/snapshots/Feature/Events/SuccessTest/reports_every_published_path_and_its_record_count_with_data_set__dataset__split_feed__.snap
+++ b/tests/.pest/snapshots/Feature/Events/SuccessTest/reports_every_published_path_and_its_record_count_with_data_set__dataset__split_feed__.snap
@@ -1,0 +1,1 @@
+end of snapshots

--- a/tests/Feature/Events/SuccessTest.php
+++ b/tests/Feature/Events/SuccessTest.php
@@ -3,10 +3,15 @@
 declare(strict_types=1);
 
 use DragonCode\LaravelFeed\Commands\FeedGenerateCommand;
+use DragonCode\LaravelFeed\Data\GenerationResultData;
 use DragonCode\LaravelFeed\Events\FeedFinishedEvent;
 use DragonCode\LaravelFeed\Events\FeedStartingEvent;
 use DragonCode\LaravelFeed\Models\Feed;
+use DragonCode\LaravelFeed\Services\GeneratorService;
 use Illuminate\Support\Facades\Event;
+use Workbench\App\Data\NewsFakeData;
+use Workbench\App\Feeds\JsonFeed;
+use Workbench\App\Feeds\SplitJsonFeed;
 
 use function Pest\Laravel\artisan;
 
@@ -24,7 +29,49 @@ test('dispatches FeedStarting and FeedFinished events for each generated feed', 
 
         Event::assertDispatched(FeedFinishedEvent::class, static function (FeedFinishedEvent $event) use ($feed) {
             return $event->feed === $feed->class
-                && $event->path === app($feed->class)->path();
+                && $event->paths !== []
+                && $event->path === $event->paths[0]
+                && collect($event->paths)->every(static fn (string $path) => is_file($path));
         });
     });
+});
+
+test('reports every published path and its record count', function (string $feedClass, array $indexes, array $counts) {
+    Event::fake();
+
+    createNews(...NewsFakeData::toArray());
+
+    $feed   = app($feedClass);
+    $paths  = array_map(static fn (int $index) => $feed->path($index), $indexes);
+    $result = app(GeneratorService::class)->feed($feed);
+
+    expect($result)
+        ->toBeInstanceOf(GenerationResultData::class)
+        ->and($result->paths)
+        ->toBe($paths)
+        ->and($result->records)
+        ->toBe(array_combine($paths, $counts));
+
+    Event::assertDispatched(FeedFinishedEvent::class, static function (FeedFinishedEvent $event) use ($feedClass, $paths) {
+        return $event->feed  === $feedClass
+            && $event->path  === $paths[0]
+            && $event->paths === $paths;
+    });
+})->with([
+    'single file' => [JsonFeed::class, [0], [3]],
+    'split feed'  => [SplitJsonFeed::class, [1, 2], [2, 1]],
+]);
+
+test('keeps the legacy finished event path compatible', function () {
+    $legacy = new FeedFinishedEvent(JsonFeed::class, 'feed.json');
+    $split  = new FeedFinishedEvent(JsonFeed::class, 'feed.json', ['feed-1.json', 'feed-2.json']);
+
+    expect($legacy->path)
+        ->toBe('feed.json')
+        ->and($legacy->paths)
+        ->toBe(['feed.json'])
+        ->and($split->path)
+        ->toBe('feed-1.json')
+        ->and($split->paths)
+        ->toBe(['feed-1.json', 'feed-2.json']);
 });

--- a/tests/Unit/Services/ExportServiceTest.php
+++ b/tests/Unit/Services/ExportServiceTest.php
@@ -61,6 +61,7 @@ test('respects split capacity', function (
     int $modelCount,
     array $expectedItems,
     array $expectedFiles,
+    array $expectedRecords,
 ) {
     $models = LazyCollection::make(function () use ($modelCount) {
         foreach (range(1, $modelCount) as $id) {
@@ -84,14 +85,16 @@ test('respects split capacity', function (
     $filesystem = mock(FilesystemService::class);
     $filesystem->shouldReceive('append')->times(count($expectedItems));
 
-    $items = [];
-    $files = [];
+    $items   = [];
+    $files   = [];
+    $records = [];
 
     (new ExportService($feed, $filesystem, null))
         ->file(
             create: fn () => fopen('php://memory', 'wb'),
-            close : function ($file, int $index) use (&$files) {
-                $files[] = $index;
+            close : function ($file, int $index, int $count) use (&$files, &$records) {
+                $files[]   = $index;
+                $records[] = $count;
 
                 fclose($file);
             }
@@ -107,27 +110,33 @@ test('respects split capacity', function (
     expect($items)
         ->toBe($expectedItems)
         ->and($files)
-        ->toBe($expectedFiles);
+        ->toBe($expectedFiles)
+        ->and($records)
+        ->toBe($expectedRecords);
 })->with([
     'single file' => [
         2,
         [[1, false], [2, true]],
         [0],
+        [2],
     ],
     'partial final file' => [
         3,
         [[1, false], [2, true], [3, true]],
         [1, 2],
+        [2, 1],
     ],
     'exact capacity' => [
         6,
         [[1, false], [2, true], [3, false], [4, true], [5, false], [6, true]],
         [1, 2, 3],
+        [2, 2, 2],
     ],
     'over capacity' => [
         10,
         [[1, false], [2, true], [3, false], [4, true], [5, false], [6, true]],
         [1, 2, 3],
+        [2, 2, 2],
     ],
 ]);
 


### PR DESCRIPTION
## Summary

- return `GenerationResultData` with published paths and per-file record counts
- expose every published path through `FeedFinishedEvent::$paths`
- keep `FeedFinishedEvent::$path` backward compatible as the first published path
- document the finished-event contract and cover single-file, split-feed, failure, and compatibility cases

## Problem

Split feeds publish suffixed files such as `feed-1.json` and `feed-2.json`, while `FeedFinishedEvent` reported the unsuffixed path. Listeners could therefore receive a path that did not exist.

## Impact

Listeners can now consume all generated files in output order. The event is still dispatched only after successful publication, and existing consumers of `$path` continue to receive one real published file.

## Validation

- `vendor\bin\pest --colors=never`: 233 tests passed, 1315 assertions
- `vendor\bin\pest --type-coverage --compact --min=95 --colors=never`: 99.6%
- targeted `vendor\bin\pint --test`: passed
- `docs/topics/events.topic`: XML is well-formed

Closes #164