### PR TITLE
perf(generation): reuse converter and transformer pipelines

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,15 @@
+# Export benchmark
+
+Run the end-to-end JSON Lines export benchmark with its default 100,000 rows, 10 fields, and three iterations:
+
+```bash
+composer benchmark
+```
+
+Override the workload when checking a local change:
+
+```bash
+composer benchmark -- --rows=200000 --iterations=5
+```
+
+The command reports elapsed time, rows per second, output bytes, and peak memory for each run and the median throughput.

--- a/benchmarks/export.php
+++ b/benchmarks/export.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+use DragonCode\LaravelFeed\Data\GenerationResultData;
+use DragonCode\LaravelFeed\Enums\FeedFormatEnum;
+use DragonCode\LaravelFeed\Feeds\Feed;
+use DragonCode\LaravelFeed\Helpers\ConverterHelper;
+use DragonCode\LaravelFeed\Queries\FeedQuery;
+use DragonCode\LaravelFeed\Services\FilesystemService;
+use DragonCode\LaravelFeed\Services\GeneratorService;
+use DragonCode\LaravelFeed\Transformers\BoolTransformer;
+use DragonCode\LaravelFeed\Transformers\DateTimeTransformer;
+use DragonCode\LaravelFeed\Transformers\EnumTransformer;
+use Illuminate\Config\Repository;
+use Illuminate\Container\Container;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Foundation\Application;
+use Illuminate\Support\LazyCollection;
+use Spatie\TemporaryDirectory\TemporaryDirectory;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+final class ExportBenchmarkModel extends Model
+{
+    public $timestamps = false;
+
+    protected $guarded = [];
+
+    public function toArray(): array
+    {
+        return $this->getAttributes();
+    }
+}
+
+final class ExportBenchmarkFeed extends Feed
+{
+    protected FeedFormatEnum $format = FeedFormatEnum::JsonLines;
+
+    public function __construct(
+        Application $laravel,
+        protected Builder $query,
+        protected string $target,
+    ) {
+        parent::__construct($laravel);
+    }
+
+    public function builder(): Builder
+    {
+        return $this->query;
+    }
+
+    public function filename(): string
+    {
+        return basename($this->target);
+    }
+
+    public function path(int|string $suffix = ''): string
+    {
+        return $this->target;
+    }
+}
+
+final class ExportBenchmarkGenerator extends GeneratorService
+{
+    protected function setLastActivity(Feed $feed): void {}
+
+    protected function started(Feed $feed): void {}
+
+    protected function finished(Feed $feed, GenerationResultData $result): void {}
+}
+
+function benchmarkBuilder(int $rows): Builder
+{
+    $createdAt = new DateTimeImmutable('2026-01-01T00:00:00+00:00');
+
+    $models = LazyCollection::make(function () use ($rows, $createdAt) {
+        for ($id = 1; $id <= $rows; $id++) {
+            $model = new ExportBenchmarkModel;
+            $model->setRawAttributes([
+                'id'          => $id,
+                'sku'         => 'SKU-' . $id,
+                'title'       => 'Benchmark product ' . $id,
+                'price'       => ($id % 10000) / 100,
+                'active'      => $id % 2 === 0,
+                'created_at'  => $createdAt,
+                'updated_at'  => $createdAt,
+                'category'    => 'category-' . ($id % 25),
+                'stock'       => $id % 500,
+                'description' => 'Representative export field set ' . $id,
+            ]);
+
+            yield $model;
+        }
+    });
+
+    $builder = Mockery::mock(Builder::class);
+    $builder->shouldNotReceive('count');
+    $builder->shouldReceive('lazyById')->once()->with(1000)->andReturn($models);
+
+    return $builder;
+}
+
+function benchmarkMedian(array $values): float
+{
+    sort($values, SORT_NUMERIC);
+
+    $middle = intdiv(count($values), 2);
+
+    if (count($values) % 2 === 1) {
+        return $values[$middle];
+    }
+
+    return ($values[$middle - 1] + $values[$middle]) / 2;
+}
+
+function benchmarkRun(
+    Application $application,
+    Filesystem $files,
+    string $target,
+    int $rows,
+): array {
+    $files->delete($target);
+
+    $feed       = new ExportBenchmarkFeed($application, benchmarkBuilder($rows), $target);
+    $filesystem = new FilesystemService($files);
+    $generator  = new ExportBenchmarkGenerator(
+        $filesystem,
+        new ConverterHelper($application),
+        Mockery::mock(FeedQuery::class),
+    );
+
+    gc_collect_cycles();
+    memory_reset_peak_usage();
+
+    $startedAt = hrtime(true);
+    $result    = $generator->feed($feed);
+    $seconds   = (hrtime(true) - $startedAt) / 1_000_000_000;
+    $records   = array_sum($result->records);
+
+    if ($records !== $rows) {
+        throw new RuntimeException("Expected [$rows] records, generated [$records].");
+    }
+
+    return [
+        'seconds'         => $seconds,
+        'rows_per_second' => $rows / $seconds,
+        'output_bytes'    => $files->size($target),
+        'peak_memory'     => memory_get_peak_usage(true),
+    ];
+}
+
+$options    = getopt('', ['rows::', 'iterations::']);
+$rows       = (int) ($options['rows'] ?? 100000);
+$iterations = (int) ($options['iterations'] ?? 3);
+
+if ($rows < 1) {
+    throw new InvalidArgumentException('The row count must be greater than zero.');
+}
+
+if ($iterations < 1) {
+    throw new InvalidArgumentException('The iteration count must be greater than zero.');
+}
+
+$temporary = (new TemporaryDirectory)
+    ->name('laravel-feeds-export-benchmark-' . bin2hex(random_bytes(8)))
+    ->create();
+$files       = new Filesystem;
+$storage     = $temporary->path('storage');
+$target      = $temporary->path('feed.jsonl');
+$application = new Application($temporary->path());
+
+$files->ensureDirectoryExists($storage . '/framework/cache/laravel-feeds');
+
+$application->useStoragePath($storage);
+$application->instance('config', new Repository([
+    'feeds' => [
+        'pretty'       => false,
+        'transformers' => [
+            BoolTransformer::class,
+            DateTimeTransformer::class,
+            EnumTransformer::class,
+        ],
+        'date' => [
+            'format'   => DATE_ATOM,
+            'timezone' => 'UTC',
+        ],
+        'converters' => [
+            'jsonl' => [
+                'options' => JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+            ],
+        ],
+    ],
+]));
+
+Container::setInstance($application);
+
+$results = [];
+
+try {
+    foreach (range(1, $iterations) as $iteration) {
+        $results[] = ['iteration' => $iteration] + benchmarkRun($application, $files, $target, $rows);
+    }
+
+    $summary = [
+        'rows'                   => $rows,
+        'fields'                 => 10,
+        'iterations'             => $iterations,
+        'median_seconds'         => benchmarkMedian(array_column($results, 'seconds')),
+        'median_rows_per_second' => benchmarkMedian(array_column($results, 'rows_per_second')),
+        'output_bytes'           => $results[0]['output_bytes'],
+        'peak_memory'            => max(array_column($results, 'peak_memory')),
+    ];
+
+    echo json_encode(
+        ['summary' => $summary, 'runs' => $results],
+        JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR
+    ) . PHP_EOL;
+} finally {
+    Mockery::close();
+    $temporary->delete();
+}

--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,7 @@
         }
     },
     "scripts": {
+        "benchmark": "@php benchmarks/export.php",
         "post-update-cmd": [
             "@php vendor/bin/codestyle pint 8.2 --ansi",
             "@php vendor/bin/codestyle editorconfig --ansi",

--- a/config/feeds.php
+++ b/config/feeds.php
@@ -67,8 +67,8 @@ return [
 
     /**
      * Transformers convert rich/complex values to simple scalar representations
-     * suitable for feeds (XML/JSON). Order matters: the first transformer that
-     * supports the value will handle it.
+     * suitable for feeds (XML/JSON). Transformers run in declaration order and
+     * each transformer receives the value produced by the previous transformer.
      *
      * You may add your own transformers by implementing
      * `DragonCode\LaravelFeed\Contracts\Transformer` and registering the class

--- a/docs/snippets/advanced-extends-transformer-config.php
+++ b/docs/snippets/advanced-extends-transformer-config.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Feeds\Transformers\PriceTransformer;
+use DragonCode\LaravelFeed\Transformers;
+
+return [
+    'transformers' => [
+        Transformers\BoolTransformer::class,
+        Transformers\DateTimeTransformer::class,
+        Transformers\EnumTransformer::class,
+        PriceTransformer::class,
+    ],
+];

--- a/docs/snippets/advanced-extends-transformer.php
+++ b/docs/snippets/advanced-extends-transformer.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Feeds\Transformers;
+
+use App\Services\PriceFormatter;
+use DragonCode\LaravelFeed\Contracts\Transformer;
+
+class PriceTransformer implements Transformer
+{
+    public function __construct(
+        protected PriceFormatter $formatter,
+    ) {}
+
+    public function allow(mixed $value): bool
+    {
+        return is_float($value);
+    }
+
+    public function transform(mixed $value): string
+    {
+        return $this->formatter->format($value);
+    }
+}

--- a/docs/topics/extending-functionality.topic
+++ b/docs/topics/extending-functionality.topic
@@ -6,9 +6,9 @@
         xsi:noNamespaceSchemaLocation="https://resources.jetbrains.com/writerside/1.0/topic.v2.xsd"
         title="Extending functionality" id="extending-functionality">
 
-    <link-summary>Extend feeds using conditional clauses and macros for Feed, FeedItem, and FeedInfo.</link-summary>
-    <card-summary>Extend feeds using conditional clauses and macros for Feed, FeedItem, and FeedInfo.</card-summary>
-    <web-summary>Extend feeds using conditional clauses and macros for Feed, FeedItem, and FeedInfo.</web-summary>
+    <link-summary>Extend feeds with conditional clauses, macros, and custom transformers.</link-summary>
+    <card-summary>Extend feeds with conditional clauses, macros, and custom transformers.</card-summary>
+    <web-summary>Extend feeds with conditional clauses, macros, and custom transformers.</web-summary>
 
     <show-structure depth="3" />
 
@@ -70,5 +70,33 @@
 
         <code-block lang="php" src="advanced-extends-macro-info.php" include-lines="5-" />
         <code-block lang="php" src="advanced-extends-macro-item.php" include-lines="5-" />
+    </chapter>
+
+    <chapter title="Custom transformers" id="custom_transformers">
+        <p>
+            A transformer converts a supported value before the converter serializes it. Register transformer class
+            names in <path>config/feeds.php</path>. Laravel resolves each class through the service container, so
+            constructor dependencies and custom container bindings are supported.
+        </p>
+
+        <code-block lang="php" src="advanced-extends-transformer.php" include-lines="5-" />
+
+        <p>
+            Add the transformer to the configured list after the built-in transformers:
+        </p>
+
+        <code-block lang="php" src="advanced-extends-transformer-config.php" />
+
+        <p>
+            The configured transformers run in declaration order. Converter-specific transformers are appended after
+            the configured list. Each <code>allow()</code> call receives the current value, including changes made by
+            earlier transformers, and every matching transformer may update it. Duplicate entries are removed after
+            container resolution while the first occurrence keeps its position.
+        </p>
+
+        <p>
+            A converter builds this ordered pipeline once and reuses the same transformer instances for every field
+            in that feed generation.
+        </p>
     </chapter>
 </topic>

--- a/src/Converters/Converter.php
+++ b/src/Converters/Converter.php
@@ -14,15 +14,13 @@ abstract class Converter
 {
     protected array $transformers = [];
 
-    protected readonly Closure $transformerPipeline;
+    protected ?Closure $transformerPipeline = null;
 
     public function __construct(
         #[Config('feeds.pretty')]
         protected bool $pretty,
         protected readonly TransformerService $transformer,
-    ) {
-        $this->transformerPipeline = $this->transformer->pipeline($this->transformers);
-    }
+    ) {}
 
     abstract public function header(Feed $feed): string;
 
@@ -41,6 +39,6 @@ abstract class Converter
 
     protected function transformValue(mixed $value): bool|float|int|string|null
     {
-        return ($this->transformerPipeline)($value);
+        return ($this->transformerPipeline ??= $this->transformer->pipeline($this->transformers))($value);
     }
 }

--- a/src/Converters/Converter.php
+++ b/src/Converters/Converter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DragonCode\LaravelFeed\Converters;
 
+use Closure;
 use DragonCode\LaravelFeed\Feeds\Feed;
 use DragonCode\LaravelFeed\Feeds\Items\FeedItem;
 use DragonCode\LaravelFeed\Services\TransformerService;
@@ -13,11 +14,15 @@ abstract class Converter
 {
     protected array $transformers = [];
 
+    protected readonly Closure $transformerPipeline;
+
     public function __construct(
         #[Config('feeds.pretty')]
         protected bool $pretty,
         protected readonly TransformerService $transformer,
-    ) {}
+    ) {
+        $this->transformerPipeline = $this->transformer->pipeline($this->transformers);
+    }
 
     abstract public function header(Feed $feed): string;
 
@@ -36,6 +41,6 @@ abstract class Converter
 
     protected function transformValue(mixed $value): bool|float|int|string|null
     {
-        return $this->transformer->transform($value, $this->transformers);
+        return ($this->transformerPipeline)($value);
     }
 }

--- a/src/Helpers/ConverterHelper.php
+++ b/src/Helpers/ConverterHelper.php
@@ -11,19 +11,29 @@ use DragonCode\LaravelFeed\Converters\JsonLinesConverter;
 use DragonCode\LaravelFeed\Converters\RssConverter;
 use DragonCode\LaravelFeed\Converters\XmlConverter;
 use DragonCode\LaravelFeed\Enums\FeedFormatEnum;
-
-use function app;
+use Illuminate\Container\Container as LaravelContainer;
+use Illuminate\Contracts\Container\Container;
 
 class ConverterHelper
 {
+    protected Container $container;
+
+    public function __construct(
+        ?Container $container = null,
+    ) {
+        $this->container = $container ?? LaravelContainer::getInstance();
+    }
+
     public function get(FeedFormatEnum $format): Converter
     {
-        return match ($format) {
-            FeedFormatEnum::Xml       => app(XmlConverter::class),
-            FeedFormatEnum::Json      => app(JsonConverter::class),
-            FeedFormatEnum::JsonLines => app(JsonLinesConverter::class),
-            FeedFormatEnum::Csv       => app(CsvConverter::class),
-            FeedFormatEnum::Rss       => app(RssConverter::class),
-        };
+        return $this->container->make(
+            match ($format) {
+                FeedFormatEnum::Xml       => XmlConverter::class,
+                FeedFormatEnum::Json      => JsonConverter::class,
+                FeedFormatEnum::JsonLines => JsonLinesConverter::class,
+                FeedFormatEnum::Csv       => CsvConverter::class,
+                FeedFormatEnum::Rss       => RssConverter::class,
+            }
+        );
     }
 }

--- a/src/Services/ExportService.php
+++ b/src/Services/ExportService.php
@@ -103,17 +103,18 @@ class ExportService
     {
         try {
             $pending = null;
+            $models  = $this->feed->builder()->lazyById($this->chunk);
 
-            foreach ($this->feed->builder()->lazyById($this->chunk) as $model) {
+            if (($limit = $this->total ?? $this->capacity) !== null) {
+                $models = $models->take($limit);
+            }
+
+            foreach ($models as $model) {
                 if ($pending instanceof Model) {
                     $this->write($pending, true);
                 }
 
                 $pending = $model;
-
-                if ($this->capacity !== null && $this->exportedRecords + 1 >= $this->capacity) {
-                    break;
-                }
             }
 
             if ($pending instanceof Model) {

--- a/src/Services/ExportService.php
+++ b/src/Services/ExportService.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Model;
 use InvalidArgumentException;
 use Symfony\Component\Console\Helper\ProgressBar;
 
+use function intdiv;
 use function is_resource;
 use function min;
 use function value;
@@ -23,11 +24,11 @@ class ExportService
 
     protected readonly int $maxFiles;
 
-    protected readonly int $modelCount;
+    protected readonly ?int $capacity;
 
-    protected int $total;
+    protected readonly ?int $total;
 
-    protected int $fileIndex;
+    protected int $fileIndex = 0;
 
     protected Closure $createFile;
 
@@ -42,29 +43,27 @@ class ExportService
 
     protected int $records = 0;
 
-    protected int $writtenFiles = 0;
+    protected int $exportedRecords = 0;
 
-    protected int $left;
+    protected int $writtenFiles = 0;
 
     protected bool $fileCreated = false;
 
     protected string $lineEnding = PHP_EOL;
+
+    protected ?int $modelCount = null;
 
     public function __construct(
         protected Feed $feed,
         protected FilesystemService $filesystem,
         protected ?OutputStyle $output,
     ) {
-        $this->perFile   = $this->perFile($this->feed);
-        $this->maxFiles  = $this->maxFiles($this->feed);
-        $this->total     = $this->total();
-        $this->fileIndex = $this->fileIndex();
+        $this->perFile  = $this->perFile($this->feed);
+        $this->maxFiles = $this->maxFiles($this->feed);
+        $this->capacity = $this->capacity();
+        $this->total    = $this->output === null ? null : $this->total();
 
-        $this->left = $this->total;
-
-        $this->progressBar = $this->createProgressBar(
-            $this->total
-        );
+        $this->progressBar = $this->total === null ? null : $this->createProgressBar($this->total);
     }
 
     public function chunk(int $chunk): static
@@ -103,26 +102,23 @@ class ExportService
     public function export(): void
     {
         try {
-            $this->feed->builder()
-                ->lazyById($this->chunk)
-                ->each(function (Model $model) {
-                    $this->records++;
-                    $this->left--;
+            $pending = null;
 
-                    $this->append(
-                        value($this->item, $model, $this->isLastItem())
-                    );
+            foreach ($this->feed->builder()->lazyById($this->chunk) as $model) {
+                if ($pending instanceof Model) {
+                    $this->write($pending, true);
+                }
 
-                    $this->store();
+                $pending = $model;
 
-                    if ($this->left <= 0) {
-                        return false;
-                    }
+                if ($this->capacity !== null && $this->exportedRecords + 1 >= $this->capacity) {
+                    break;
+                }
+            }
 
-                    if ($this->maxFiles && $this->writtenFiles >= $this->maxFiles) {
-                        return false;
-                    }
-                });
+            if ($pending instanceof Model) {
+                $this->write($pending, false);
+            }
 
             $this->store(true);
 
@@ -138,7 +134,7 @@ class ExportService
 
     protected function store(bool $force = false): void
     {
-        $whenRecords = $this->records >= $this->perFile;
+        $whenRecords = $this->perFile > 0 && $this->records >= $this->perFile;
 
         if ($force && ! $this->fileCreated) {
             $this->getFile();
@@ -150,9 +146,26 @@ class ExportService
         }
     }
 
-    protected function isLastItem(): bool
+    protected function write(Model $model, bool $hasNext): void
     {
-        return $this->records === $this->perFile || $this->left <= 0;
+        $this->records++;
+        $this->exportedRecords++;
+
+        $fileCompleted = $this->perFile > 0 && $this->records >= $this->perFile;
+
+        if ($this->writtenFiles === 0 && $fileCompleted && $hasNext) {
+            $this->fileIndex = 1;
+        }
+
+        $this->append(
+            value($this->item, $model, $fileCompleted || ! $hasNext)
+        );
+
+        $this->progressBar?->advance();
+
+        if ($fileCompleted) {
+            $this->store();
+        }
     }
 
     protected function getFile() // @pest-ignore-type
@@ -198,11 +211,7 @@ class ExportService
             throw new InvalidArgumentException("Feed perFile must be greater than or equal to 0, [$count] given.");
         }
 
-        if ($count) {
-            return $count;
-        }
-
-        return $this->modelCount();
+        return $count;
     }
 
     protected function maxFiles(Feed $feed): int
@@ -218,27 +227,27 @@ class ExportService
 
     protected function total(): int
     {
-        if ($this->maxFiles === 0) {
+        if ($this->capacity === null) {
             return $this->modelCount();
         }
 
         return min(
             $this->modelCount(),
-            $this->perFile * $this->maxFiles
+            $this->capacity
         );
     }
 
-    protected function fileIndex(): int
+    protected function capacity(): ?int
     {
-        if ($this->perFile === 0 || $this->perFile === $this->total) {
-            return 0;
+        if ($this->perFile === 0 || $this->maxFiles === 0) {
+            return null;
         }
 
-        if ($this->perFile >= $this->total) {
-            return 0;
+        if ($this->maxFiles > intdiv(PHP_INT_MAX, $this->perFile)) {
+            return PHP_INT_MAX;
         }
 
-        return 1;
+        return $this->perFile * $this->maxFiles;
     }
 
     protected function modelCount(): int

--- a/src/Services/GeneratorService.php
+++ b/src/Services/GeneratorService.php
@@ -46,16 +46,17 @@ class GeneratorService
         try {
             $this->started($feed);
 
-            $result = null;
+            $converter = $this->converter($feed);
+            $result    = null;
 
-            $this->filesystem->publish($path, function (string $staging) use ($feed, $output, &$result) {
+            $this->filesystem->publish($path, function (string $staging) use ($feed, $output, $converter, &$result) {
                 $this->debug($output, 'Publication lock acquired and staging created.', [
                     'feed'    => get_class($feed),
                     'staging' => $staging,
                 ]);
 
                 $drafts = [];
-                $result = $this->export($feed, $output, $this->filesystem, $staging, $drafts);
+                $result = $this->export($feed, $output, $this->filesystem, $staging, $drafts, $converter);
 
                 $this->debug($output, 'All feed parts staged.', [
                     'feed'    => get_class($feed),
@@ -105,9 +106,9 @@ class GeneratorService
         FilesystemService $filesystem,
         string $staging,
         array &$drafts,
+        Converter $converter,
     ): GenerationResultData {
-        $records   = [];
-        $converter = $this->converter($feed);
+        $records = [];
 
         (new ExportService($feed, $filesystem, $output))
             ->file(

--- a/src/Services/TransformerService.php
+++ b/src/Services/TransformerService.php
@@ -4,29 +4,60 @@ declare(strict_types=1);
 
 namespace DragonCode\LaravelFeed\Services;
 
+use Closure;
+use DragonCode\LaravelFeed\Contracts\Transformer;
+use Illuminate\Container\Attributes\Config;
+use Illuminate\Container\Container as LaravelContainer;
+use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\Collection;
 
 use function config;
+use function implode;
 
 class TransformerService
 {
-    public function transform(mixed $value, array $transformers = []): bool|float|int|string|null
-    {
-        foreach ($this->transformers($transformers) as $transformer) {
-            if ($transformer->allow($value)) {
-                $value = $transformer->transform($value);
-            }
-        }
+    protected array $pipelines = [];
 
-        return $value;
+    protected Container $container;
+
+    protected array $configuredTransformers;
+
+    public function __construct(
+        ?Container $container = null,
+        #[Config('feeds.transformers')]
+        ?array $configuredTransformers = null,
+    ) {
+        $this->container              = $container              ?? LaravelContainer::getInstance();
+        $this->configuredTransformers = $configuredTransformers ?? config('feeds.transformers', []);
     }
 
-    /** @return \DragonCode\LaravelFeed\Contracts\Transformer[] */
+    public function transform(mixed $value, array $transformers = []): bool|float|int|string|null
+    {
+        $key = implode('|', $transformers);
+
+        return ($this->pipelines[$key] ??= $this->pipeline($transformers))($value);
+    }
+
+    public function pipeline(array $transformers = []): Closure
+    {
+        $pipeline = $this->transformers($transformers);
+
+        return static function (mixed $value) use ($pipeline): bool|float|int|string|null {
+            foreach ($pipeline as $transformer) {
+                if ($transformer->allow($value)) {
+                    $value = $transformer->transform($value);
+                }
+            }
+
+            return $value;
+        };
+    }
+
     protected function transformers(array $transformers): array
     {
-        return (new Collection(config('feeds.transformers')))
+        return (new Collection($this->configuredTransformers))
             ->merge($transformers)
-            ->map(static fn (string $transformer) => new $transformer)
+            ->map(fn (string $transformer): Transformer => $this->container->make($transformer))
             ->unique()
             ->all();
     }

--- a/tests/.pest/snapshots/Feature/Feeds/ConverterResolutionTest/resolves_one_converter_for_each_generation_regardless_of_row_count.snap
+++ b/tests/.pest/snapshots/Feature/Feeds/ConverterResolutionTest/resolves_one_converter_for_each_generation_regardless_of_row_count.snap
@@ -1,0 +1,1 @@
+end of snapshots

--- a/tests/Feature/Feeds/ConverterResolutionTest.php
+++ b/tests/Feature/Feeds/ConverterResolutionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use DragonCode\LaravelFeed\Converters\JsonConverter;
+use DragonCode\LaravelFeed\Services\GeneratorService;
+use Workbench\App\Feeds\SplitJsonFeed;
+use Workbench\App\Models\News;
+
+test('resolves one converter for each generation regardless of row count', function () {
+    $resolutions = 0;
+
+    app()->resolving(JsonConverter::class, function () use (&$resolutions) {
+        $resolutions++;
+    });
+
+    News::factory()->count(1)->create();
+
+    app(GeneratorService::class)->feed(app(SplitJsonFeed::class));
+
+    News::factory()->count(20)->create();
+
+    app(GeneratorService::class)->feed(app(SplitJsonFeed::class));
+
+    expect($resolutions)->toBe(2);
+});

--- a/tests/Unit/Converters/ConverterTest.php
+++ b/tests/Unit/Converters/ConverterTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use DragonCode\LaravelFeed\Contracts\Transformer;
+use DragonCode\LaravelFeed\Converters\JsonConverter;
+use DragonCode\LaravelFeed\Feeds\Items\FeedItem;
+use DragonCode\LaravelFeed\Services\TransformerService;
+
+final class ConstructorConfiguredTransformer implements Transformer
+{
+    public static int $instances = 0;
+
+    public function __construct()
+    {
+        self::$instances++;
+    }
+
+    public function allow(mixed $value): bool
+    {
+        return is_string($value);
+    }
+
+    public function transform(mixed $value): string
+    {
+        return $value . ':custom';
+    }
+}
+
+final class ConstructorConfiguredJsonConverter extends JsonConverter
+{
+    public function __construct(TransformerService $transformer)
+    {
+        parent::__construct(JSON_THROW_ON_ERROR, false, $transformer);
+
+        $this->transformers[] = ConstructorConfiguredTransformer::class;
+    }
+}
+
+test('compiles the transformer pipeline after subclass construction', function () {
+    ConstructorConfiguredTransformer::$instances = 0;
+
+    $first = mock(FeedItem::class);
+    $first->shouldReceive('toArray')->once()->andReturn(['value' => 'first']);
+
+    $second = mock(FeedItem::class);
+    $second->shouldReceive('toArray')->once()->andReturn(['value' => 'second']);
+
+    $converter = new ConstructorConfiguredJsonConverter(
+        new TransformerService(app(), [])
+    );
+
+    expect($converter->item($first, true))
+        ->toBe('{"value":"first:custom"}')
+        ->and($converter->item($second, true))
+        ->toBe('{"value":"second:custom"}')
+        ->and(ConstructorConfiguredTransformer::$instances)
+        ->toBe(1);
+});

--- a/tests/Unit/Services/ExportServiceTest.php
+++ b/tests/Unit/Services/ExportServiceTest.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 use DragonCode\LaravelFeed\Feeds\Feed;
 use DragonCode\LaravelFeed\Services\ExportService;
 use DragonCode\LaravelFeed\Services\FilesystemService;
+use Illuminate\Console\OutputStyle;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\LazyCollection;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
 
 test('writes each serialized item immediately', function (string $lineEnding) {
     $models = LazyCollection::make(function () {
@@ -20,13 +23,13 @@ test('writes each serialized item immediately', function (string $lineEnding) {
     });
 
     $builder = mock(Builder::class);
-    $builder->shouldReceive('count')->once()->andReturn(3);
+    $builder->shouldNotReceive('count');
     $builder->shouldReceive('lazyById')->once()->with(2)->andReturn($models);
 
     $feed = mock(Feed::class);
     $feed->shouldReceive('perFile')->once()->andReturn(0);
     $feed->shouldReceive('maxFiles')->once()->andReturn(0);
-    $feed->shouldReceive('builder')->twice()->andReturn($builder);
+    $feed->shouldReceive('builder')->once()->andReturn($builder);
     $feed->shouldReceive('path')->times(3)->andReturn('feed.xml');
 
     $writes = [];
@@ -73,13 +76,13 @@ test('respects split capacity', function (
     });
 
     $builder = mock(Builder::class);
-    $builder->shouldReceive('count')->once()->andReturn($modelCount);
+    $builder->shouldNotReceive('count');
     $builder->shouldReceive('lazyById')->once()->with(2)->andReturn($models);
 
     $feed = mock(Feed::class);
     $feed->shouldReceive('perFile')->once()->andReturn(2);
     $feed->shouldReceive('maxFiles')->once()->andReturn(3);
-    $feed->shouldReceive('builder')->twice()->andReturn($builder);
+    $feed->shouldReceive('builder')->once()->andReturn($builder);
     $feed->shouldReceive('path')->times(count($expectedItems))->andReturn('feed.json');
 
     $filesystem = mock(FilesystemService::class);
@@ -158,13 +161,10 @@ test('rejects a negative file limit', function () {
 });
 
 test('rejects a non-positive chunk size', function (int $chunk) {
-    $builder = mock(Builder::class);
-    $builder->shouldReceive('count')->once()->andReturn(1);
-
     $feed = mock(Feed::class);
     $feed->shouldReceive('perFile')->once()->andReturn(1);
     $feed->shouldReceive('maxFiles')->once()->andReturn(0);
-    $feed->shouldReceive('builder')->once()->andReturn($builder);
+    $feed->shouldNotReceive('builder');
 
     $service = new ExportService($feed, mock(FilesystemService::class), null);
 
@@ -176,13 +176,13 @@ test('closes the active resource when export fails', function () {
     $model = mock(Model::class);
 
     $builder = mock(Builder::class);
-    $builder->shouldReceive('count')->once()->andReturn(1);
+    $builder->shouldNotReceive('count');
     $builder->shouldReceive('lazyById')->once()->with(1)->andReturn(LazyCollection::make([$model]));
 
     $feed = mock(Feed::class);
     $feed->shouldReceive('perFile')->once()->andReturn(0);
     $feed->shouldReceive('maxFiles')->once()->andReturn(0);
-    $feed->shouldReceive('builder')->twice()->andReturn($builder);
+    $feed->shouldReceive('builder')->once()->andReturn($builder);
     $feed->shouldReceive('path')->once()->andReturn('feed.json');
 
     $resource = fopen('php://memory', 'wb');
@@ -203,4 +203,75 @@ test('closes the active resource when export fails', function () {
         ->toThrow(RuntimeException::class, 'Write failed.')
         ->and(is_resource($resource))
         ->toBeFalse();
+});
+
+test('creates an empty feed without counting models', function () {
+    $builder = mock(Builder::class);
+    $builder->shouldNotReceive('count');
+    $builder->shouldReceive('lazyById')->once()->with(10)->andReturn(LazyCollection::make([]));
+
+    $feed = mock(Feed::class);
+    $feed->shouldReceive('perFile')->once()->andReturn(0);
+    $feed->shouldReceive('maxFiles')->once()->andReturn(0);
+    $feed->shouldReceive('builder')->once()->andReturn($builder);
+
+    $filesystem = mock(FilesystemService::class);
+    $filesystem->shouldNotReceive('append');
+
+    $files   = [];
+    $records = [];
+
+    (new ExportService($feed, $filesystem, null))
+        ->file(
+            create: fn () => fopen('php://memory', 'wb'),
+            close : function ($file, int $index, int $count) use (&$files, &$records) {
+                $files[]   = $index;
+                $records[] = $count;
+
+                fclose($file);
+            }
+        )
+        ->item(fn () => throw new RuntimeException('No item should be serialized.'))
+        ->chunk(10)
+        ->export();
+
+    expect($files)
+        ->toBe([0])
+        ->and($records)
+        ->toBe([0]);
+});
+
+test('counts models once when progress reporting needs an exact total', function () {
+    $models = LazyCollection::make(function () {
+        foreach (range(1, 3) as $id) {
+            $model = mock(Model::class);
+            $model->shouldReceive('getKey')->andReturn($id);
+
+            yield $model;
+        }
+    });
+
+    $builder = mock(Builder::class);
+    $builder->shouldReceive('count')->once()->andReturn(3);
+    $builder->shouldReceive('lazyById')->once()->with(2)->andReturn($models);
+
+    $feed = mock(Feed::class);
+    $feed->shouldReceive('perFile')->once()->andReturn(0);
+    $feed->shouldReceive('maxFiles')->once()->andReturn(0);
+    $feed->shouldReceive('builder')->twice()->andReturn($builder);
+    $feed->shouldReceive('path')->times(3)->andReturn('feed.jsonl');
+
+    $output = new OutputStyle(new ArrayInput([]), new BufferedOutput);
+
+    $filesystem = mock(FilesystemService::class);
+    $filesystem->shouldReceive('append')->times(3);
+
+    (new ExportService($feed, $filesystem, $output))
+        ->file(
+            create: fn () => fopen('php://memory', 'wb'),
+            close : fn ($file) => fclose($file)
+        )
+        ->item(fn (Model $model) => 'item-' . $model->getKey())
+        ->chunk(2)
+        ->export();
 });

--- a/tests/Unit/Services/ExportServiceTest.php
+++ b/tests/Unit/Services/ExportServiceTest.php
@@ -275,3 +275,50 @@ test('counts models once when progress reporting needs an exact total', function
         ->chunk(2)
         ->export();
 });
+
+test('stops progress exports at the counted total', function () {
+    $models = LazyCollection::make(function () {
+        foreach (range(1, 5) as $id) {
+            $model = mock(Model::class);
+            $model->shouldReceive('getKey')->andReturn($id);
+
+            yield $model;
+        }
+    });
+
+    $builder = mock(Builder::class);
+    $builder->shouldReceive('count')->once()->andReturn(3);
+    $builder->shouldReceive('lazyById')->once()->with(2)->andReturn($models);
+
+    $feed = mock(Feed::class);
+    $feed->shouldReceive('perFile')->once()->andReturn(0);
+    $feed->shouldReceive('maxFiles')->once()->andReturn(0);
+    $feed->shouldReceive('builder')->twice()->andReturn($builder);
+    $feed->shouldReceive('path')->andReturn('feed.jsonl');
+
+    $output = new OutputStyle(new ArrayInput([]), new BufferedOutput);
+
+    $filesystem = mock(FilesystemService::class);
+    $filesystem->shouldReceive('append');
+
+    $items = [];
+
+    (new ExportService($feed, $filesystem, $output))
+        ->file(
+            create: fn () => fopen('php://memory', 'wb'),
+            close : fn ($file) => fclose($file)
+        )
+        ->item(function (Model $model, bool $isLast) use (&$items) {
+            $items[] = [$model->getKey(), $isLast];
+
+            return 'item-' . $model->getKey();
+        })
+        ->chunk(2)
+        ->export();
+
+    expect($items)->toBe([
+        [1, false],
+        [2, false],
+        [3, true],
+    ]);
+});

--- a/tests/Unit/Services/TransformerServiceTest.php
+++ b/tests/Unit/Services/TransformerServiceTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+use DragonCode\LaravelFeed\Contracts\Transformer;
+use DragonCode\LaravelFeed\Services\TransformerService;
+
+final class TransformerPipelineDependency {}
+
+final class TransformerPipelineFirst implements Transformer
+{
+    public static int $instances = 0;
+
+    public static int $calls = 0;
+
+    public function __construct(
+        public TransformerPipelineDependency $dependency,
+    ) {
+        self::$instances++;
+    }
+
+    public function allow(mixed $value): bool
+    {
+        return is_string($value);
+    }
+
+    public function transform(mixed $value): string
+    {
+        self::$calls++;
+
+        return $value . ':first';
+    }
+}
+
+final class TransformerPipelineSecond implements Transformer
+{
+    public static int $instances = 0;
+
+    public static int $calls = 0;
+
+    public function __construct(
+        public TransformerPipelineDependency $dependency,
+    ) {
+        self::$instances++;
+    }
+
+    public function allow(mixed $value): bool
+    {
+        return is_string($value);
+    }
+
+    public function transform(mixed $value): string
+    {
+        self::$calls++;
+
+        return $value . ':second';
+    }
+}
+
+beforeEach(function () {
+    TransformerPipelineFirst::$instances  = 0;
+    TransformerPipelineFirst::$calls      = 0;
+    TransformerPipelineSecond::$instances = 0;
+    TransformerPipelineSecond::$calls     = 0;
+});
+
+test('resolves an ordered transformer pipeline once through the container', function () {
+    app()->singleton(TransformerPipelineDependency::class);
+
+    $service  = new TransformerService(app(), [TransformerPipelineFirst::class]);
+    $pipeline = $service->pipeline([TransformerPipelineSecond::class]);
+
+    expect($pipeline('value'))
+        ->toBe('value:first:second')
+        ->and($pipeline('next'))
+        ->toBe('next:first:second')
+        ->and(TransformerPipelineFirst::$instances)
+        ->toBe(1)
+        ->and(TransformerPipelineSecond::$instances)
+        ->toBe(1)
+        ->and(TransformerPipelineFirst::$calls)
+        ->toBe(2)
+        ->and(TransformerPipelineSecond::$calls)
+        ->toBe(2);
+});
+
+test('reuses a compiled pipeline for repeated service transformations', function () {
+    $service = new TransformerService(app(), [TransformerPipelineFirst::class]);
+
+    expect($service->transform('value', [TransformerPipelineSecond::class]))
+        ->toBe('value:first:second')
+        ->and($service->transform('next', [TransformerPipelineSecond::class]))
+        ->toBe('next:first:second')
+        ->and(TransformerPipelineFirst::$instances)
+        ->toBe(1)
+        ->and(TransformerPipelineSecond::$instances)
+        ->toBe(1);
+});


### PR DESCRIPTION
## Summary

- resolve one converter for an entire feed generation
- compile ordered transformer pipelines once and resolve custom transformers through Laravel's container
- avoid model count queries unless progress reporting needs an exact total
- add regression coverage, documentation, and a repeatable 100,000-row benchmark

## Impact

Large feeds now scale converter and transformer allocation with generation jobs instead of rows and fields. One-item lookahead preserves split naming, last-item serialization, and existing output behavior.

## Validation

- `composer test` — 238 tests, 1340 assertions
- `composer test:type` — 99.6%
- `composer test:coverage` with Xdebug coverage — 95.5%
- `vendor/bin/pint --test --dirty` — passed
- `composer benchmark -- --rows=100000 --iterations=1` — 17,889 rows/s, peak memory 6 MiB

Closes #165