### PR TITLE
Validate generated feed formats semantically

### DIFF
--- a/tests/Expectations.php
+++ b/tests/Expectations.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 expect()->extend('toMatchFileSnapshot', function () {
-    $content = file_get_contents($this->value);
+    $content = readFeedFile($this->value);
 
     expect($content)->toMatchSnapshot();
 
@@ -56,27 +56,126 @@ expect()->pipe('toMatchSnapshot', function (Closure $next) {
     return $next();
 });
 
-expect()->extend('toBeJsonLines', function () {
-    foreach (explode("\n", $this->value) as $line) {
-        expect($line)->toBeJson();
-    }
+expect()->extend('toBeJsonDocument', function () {
+    expect(parseJsonDocument($this->value))->toBeArray();
 
     return $this;
 });
 
-expect()->extend('toBeCsv', function () {
+expect()->extend('toBeJsonLines', function () {
+    expect(parseJsonLines($this->value))->not->toBeEmpty();
+
+    return $this;
+});
+
+expect()->extend('toBeCsv', function (?array $expectedRows = null) {
     $rows = parseCsv($this->value);
 
-    expect($rows)->not->toBeEmpty();
+    if ($rows === []) {
+        throw new RuntimeException('Invalid CSV: expected at least one row.');
+    }
 
     $columns = count($rows[0]);
 
-    foreach ($rows as $row) {
-        expect($row)->toHaveCount($columns);
+    foreach ($rows as $index => $row) {
+        $actualColumns = count($row);
+
+        if ($actualColumns !== $columns) {
+            $line = $index + 1;
+
+            throw new RuntimeException(
+                "Invalid CSV row at line [$line]: expected [$columns] columns, got [$actualColumns]."
+            );
+        }
+
+        if ($row === [null]) {
+            $line = $index + 1;
+
+            throw new RuntimeException("Invalid CSV row at line [$line]: empty records are not allowed.");
+        }
+    }
+
+    if ($expectedRows !== null) {
+        expect($rows)->toBe($expectedRows);
+    } else {
+        expect($rows)->toBeArray();
     }
 
     return $this;
 });
+
+function readFeedFile(string $path): string
+{
+    if (! is_file($path) || ! is_readable($path)) {
+        throw new RuntimeException("Unable to read generated feed file: [$path].");
+    }
+
+    $content = file_get_contents($path);
+
+    if ($content === false) {
+        throw new RuntimeException("Unable to read generated feed file: [$path].");
+    }
+
+    return $content;
+}
+
+function parseJsonDocument(string $content): array
+{
+    $value = decodeJsonFeed($content, 'JSON document');
+
+    if (! is_array($value)) {
+        throw new RuntimeException('Invalid JSON document: expected an object or array.');
+    }
+
+    return $value;
+}
+
+function parseJsonLines(string $content): array
+{
+    if ($content === '') {
+        throw new RuntimeException('Invalid JSON Lines: expected at least one record.');
+    }
+
+    $normalized = str_replace(["\r\n", "\r"], "\n", $content);
+    $lines      = explode("\n", $normalized);
+
+    if (str_ends_with($normalized, "\n")) {
+        array_pop($lines);
+    }
+
+    $records = [];
+
+    foreach ($lines as $index => $line) {
+        $number = $index + 1;
+        $value  = decodeJsonFeed($line, "JSON Lines record at line [$number]");
+
+        if (! is_array($value)) {
+            throw new RuntimeException(
+                "Invalid JSON Lines record at line [$number]: expected an object or array."
+            );
+        }
+
+        $records[] = $value;
+    }
+
+    return $records;
+}
+
+function decodeJsonFeed(string $content, string $context): mixed
+{
+    try {
+        return json_decode(
+            json       : $content,
+            associative: true,
+            flags      : JSON_THROW_ON_ERROR
+        );
+    } catch (JsonException $exception) {
+        throw new RuntimeException(
+            "Invalid $context: {$exception->getMessage()}",
+            previous: $exception
+        );
+    }
+}
 
 function parseCsv(string $content): array
 {
@@ -116,15 +215,38 @@ function parseCsv(string $content): array
 }
 
 expect()->extend('toBeXml', function () {
-    parseXmlDocument($this->value);
+    $document = parseXmlDocument($this->value);
+
+    expect($document->documentElement)->toBeInstanceOf(DOMElement::class);
 
     return $this;
 });
 
 expect()->extend('toBeRss', function () {
     $document = parseXmlDocument($this->value);
+    $root     = $document->documentElement;
 
-    expect($document->documentElement?->nodeName)->toBe('rss');
+    if ($root?->nodeName !== 'rss') {
+        throw new RuntimeException('Invalid RSS: expected the root element [rss].');
+    }
+
+    if ($root->getAttribute('version') !== '2.0') {
+        throw new RuntimeException('Invalid RSS: expected version [2.0].');
+    }
+
+    $channels = 0;
+
+    foreach ($root->childNodes as $node) {
+        if ($node instanceof DOMElement && $node->nodeName === 'channel') {
+            $channels++;
+        }
+    }
+
+    if ($channels !== 1) {
+        throw new RuntimeException('Invalid RSS: expected exactly one [channel] element.');
+    }
+
+    expect($root)->toBeInstanceOf(DOMElement::class);
 
     return $this;
 });
@@ -134,16 +256,29 @@ function parseXmlDocument(string $content): DOMDocument
     $document       = new DOMDocument;
     $internalErrors = libxml_use_internal_errors(true);
 
+    libxml_clear_errors();
+
     try {
         $loaded = $document->loadXML($content, LIBXML_NONET);
-        $error  = libxml_get_last_error();
+        $errors = libxml_get_errors();
+    } catch (Throwable $exception) {
+        throw new RuntimeException(
+            "Invalid XML: {$exception->getMessage()}",
+            previous: $exception
+        );
     } finally {
         libxml_clear_errors();
         libxml_use_internal_errors($internalErrors);
     }
 
-    if (! $loaded) {
-        $reason = $error ? trim($error->message) : 'Unknown parsing error.';
+    if (! $loaded || $errors !== []) {
+        $messages = [];
+
+        foreach ($errors as $error) {
+            $messages[] = trim($error->message);
+        }
+
+        $reason = $messages === [] ? 'Unknown parsing error.' : implode('; ', $messages);
 
         throw new RuntimeException("Invalid XML: $reason");
     }

--- a/tests/Feature/Feeds/Formats/Csv/DefaultTest.php
+++ b/tests/Feature/Feeds/Formats/Csv/DefaultTest.php
@@ -14,7 +14,7 @@ test('export', function (bool $pretty) {
     expectFeedSnapshot(CsvFeed::class, FeedFormatEnum::Csv);
 
     $rows = parseCsv(
-        file_get_contents(app(CsvFeed::class)->path())
+        readFeedFile(app(CsvFeed::class)->path())
     );
 
     expect($rows[0][1])

--- a/tests/Feature/Feeds/Formats/Csv/InfoTest.php
+++ b/tests/Feature/Feeds/Formats/Csv/InfoTest.php
@@ -13,6 +13,6 @@ test('export', function (bool $pretty) {
 
     expectFeedSnapshot(CsvInfoFeed::class, FeedFormatEnum::Csv);
 
-    expect(parseCsv(file_get_contents(app(CsvInfoFeed::class)->path()))[0])
+    expect(parseCsv(readFeedFile(app(CsvInfoFeed::class)->path()))[0])
         ->toBe(['id', 'title', 'content', 'category', 'created_at', 'updated_at']);
 })->with('boolean');

--- a/tests/Feature/Feeds/Formats/Csv/RootInfoTest.php
+++ b/tests/Feature/Feeds/Formats/Csv/RootInfoTest.php
@@ -13,6 +13,6 @@ test('export', function (bool $pretty) {
 
     expectFeedSnapshot(CsvRootInfoFeed::class, FeedFormatEnum::Csv);
 
-    expect(parseCsv(file_get_contents(app(CsvRootInfoFeed::class)->path()))[0])
+    expect(parseCsv(readFeedFile(app(CsvRootInfoFeed::class)->path()))[0])
         ->toBe(['id', 'title', 'content', 'category', 'created_at', 'updated_at']);
 })->with('boolean');

--- a/tests/Feature/Feeds/Split/CsvTest.php
+++ b/tests/Feature/Feeds/Split/CsvTest.php
@@ -13,8 +13,8 @@ test('export', function () {
 
     $feed = app(SplitCsvFeed::class);
 
-    $first  = parseCsv(file_get_contents($feed->path(1)));
-    $second = parseCsv(file_get_contents($feed->path(2)));
+    $first  = parseCsv(readFeedFile($feed->path(1)));
+    $second = parseCsv(readFeedFile($feed->path(2)));
 
     expect($first)
         ->toHaveCount(2)

--- a/tests/Feature/Feeds/Split/JsonLinesTest.php
+++ b/tests/Feature/Feeds/Split/JsonLinesTest.php
@@ -10,4 +10,14 @@ test('export', function () {
     createNews(...NewsFakeData::toArray());
 
     expectFeedSnapshot(SplitJsonLinesFeed::class, FeedFormatEnum::JsonLines, indexes: [1, 2]);
+
+    $feed = app(SplitJsonLinesFeed::class);
+
+    $first  = parseJsonLines(readFeedFile($feed->path(1)));
+    $second = parseJsonLines(readFeedFile($feed->path(2)));
+
+    expect(array_column($first, 'title'))
+        ->toBe(['Some 1', 'Some 2'])
+        ->and(array_column($second, 'title'))
+        ->toBe(['Some 3']);
 });

--- a/tests/Feature/Feeds/Split/JsonTest.php
+++ b/tests/Feature/Feeds/Split/JsonTest.php
@@ -12,4 +12,14 @@ test('export', function () {
     createNews(...NewsFakeData::toArray());
 
     expectFeedSnapshot(SplitJsonFeed::class, FeedFormatEnum::Json, indexes: [1, 2]);
+
+    $feed = app(SplitJsonFeed::class);
+
+    $first  = parseJsonDocument(readFeedFile($feed->path(1)));
+    $second = parseJsonDocument(readFeedFile($feed->path(2)));
+
+    expect(array_column($first, 'title'))
+        ->toBe(['Some 1', 'Some 2'])
+        ->and(array_column($second, 'title'))
+        ->toBe(['Some 3']);
 });

--- a/tests/Feature/Feeds/Split/RssTest.php
+++ b/tests/Feature/Feeds/Split/RssTest.php
@@ -10,4 +10,19 @@ test('export', function () {
     createNews(...NewsFakeData::toArray());
 
     expectFeedSnapshot(SplitRssFeed::class, FeedFormatEnum::Rss, indexes: [1, 2]);
+
+    $feed = app(SplitRssFeed::class);
+
+    $first  = parseXmlDocument(readFeedFile($feed->path(1)));
+    $second = parseXmlDocument(readFeedFile($feed->path(2)));
+
+    $firstTitles  = $first->getElementsByTagName('title');
+    $secondTitles = $second->getElementsByTagName('title');
+
+    expect($firstTitles->item(0)?->textContent)
+        ->toBe('Some 1')
+        ->and($firstTitles->item(1)?->textContent)
+        ->toBe('Some 2')
+        ->and($secondTitles->item(0)?->textContent)
+        ->toBe('Some 3');
 });

--- a/tests/Feature/Feeds/Split/XmlTest.php
+++ b/tests/Feature/Feeds/Split/XmlTest.php
@@ -9,4 +9,16 @@ test('export', function () {
     createNews(...NewsFakeData::toArray());
 
     expectFeedSnapshot(SplitXmlFeed::class, indexes: [1, 2]);
+
+    $feed = app(SplitXmlFeed::class);
+
+    $first  = parseXmlDocument(readFeedFile($feed->path(1)));
+    $second = parseXmlDocument(readFeedFile($feed->path(2)));
+
+    expect($first->getElementsByTagName('record_title')->item(0)?->textContent)
+        ->toBe('[NEWS]:Some 1')
+        ->and($first->getElementsByTagName('record_title')->item(1)?->textContent)
+        ->toBe('[NEWS]:Some 2')
+        ->and($second->getElementsByTagName('record_title')->item(0)?->textContent)
+        ->toBe('[NEWS]:Some 3');
 });

--- a/tests/Helpers/expects.php
+++ b/tests/Helpers/expects.php
@@ -21,12 +21,12 @@ function expectFeedSnapshot(string $class, ?FeedFormatEnum $format = null, array
     foreach ($indexes as $index) {
         expect($instance->path($index))->toBeFile();
 
-        $content = file_get_contents($instance->path($index));
+        $content = readFeedFile($instance->path($index));
 
         expect($content)->toMatchSnapshot();
 
         match ($format) {
-            FeedFormatEnum::Json      => expect($content)->toBeJson(),
+            FeedFormatEnum::Json      => expect($content)->toBeJsonDocument(),
             FeedFormatEnum::JsonLines => expect($content)->toBeJsonLines(),
             FeedFormatEnum::Csv       => expect($content)->toBeCsv(),
             FeedFormatEnum::Rss       => expect($content)->toBeRss(),

--- a/tests/Unit/FormatExpectationsTest.php
+++ b/tests/Unit/FormatExpectationsTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+use Spatie\TemporaryDirectory\TemporaryDirectory;
+
+test('accepts valid format fixtures containing special characters', function (
+    string $expectation,
+    string $content,
+    array $arguments,
+) {
+    $assertion = expect($content);
+
+    $assertion->{$expectation}(...$arguments);
+})->with([
+    'XML' => [
+        'toBeXml',
+        '<?xml version="1.0" encoding="UTF-8"?><feed label="A &amp; B &quot;quoted&quot;"><item>Привет &lt;мир&gt; 😀</item></feed>',
+        [],
+    ],
+    'RSS' => [
+        'toBeRss',
+        '<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"><channel><title>A &amp; B</title><item><description>Привет &lt;мир&gt; 😀</description></item></channel></rss>',
+        [],
+    ],
+    'JSON' => [
+        'toBeJsonDocument',
+        '{"value":"A & B \"quoted\" <tag> 😀","line":"first\nsecond"}',
+        [],
+    ],
+    'JSON Lines' => [
+        'toBeJsonLines',
+        '{"value":"A & B \"quoted\""}' . "\r\n" . '{"value":"Привет <мир> 😀"}' . "\r\n",
+        [],
+    ],
+    'CSV' => [
+        'toBeCsv',
+        '"A;B";"value ""quoted""";"Первая строка' . "\r\n" . 'Вторая строка"' . "\r\n"
+            . '"😀";"<tag> & value";""',
+        [[
+            [
+                'A;B',
+                'value "quoted"',
+                "Первая строка\r\nВторая строка",
+            ],
+            [
+                '😀',
+                '<tag> & value',
+                '',
+            ],
+        ]],
+    ],
+]);
+
+test('rejects malformed format fixtures', function (string $expectation, string $content) {
+    expect(fn () => expect($content)->{$expectation}())
+        ->toThrow(RuntimeException::class);
+})->with([
+    'XML' => [
+        'toBeXml',
+        '<feed><item></feed>',
+    ],
+    'RSS' => [
+        'toBeRss',
+        '<feed><channel/></feed>',
+    ],
+    'JSON' => [
+        'toBeJsonDocument',
+        '{"value":}',
+    ],
+    'JSON Lines' => [
+        'toBeJsonLines',
+        '{"id":1}' . "\n" . '{"id":}',
+    ],
+    'CSV' => [
+        'toBeCsv',
+        "first;second\nonly-one",
+    ],
+]);
+
+test('parses semantic values without losing special characters', function () {
+    $json  = parseJsonDocument('{"value":"A & B \"quoted\" <tag> 😀"}');
+    $lines = parseJsonLines(
+        '{"value":"A & B \"quoted\""}' . "\n" . '{"value":"Привет <мир> 😀"}'
+    );
+    $xml = parseXmlDocument(
+        '<feed label="A &amp; B &quot;quoted&quot;"><item>Привет &lt;мир&gt; 😀</item></feed>'
+    );
+
+    expect($json)
+        ->toBe(['value' => 'A & B "quoted" <tag> 😀'])
+        ->and($lines)
+        ->toBe([
+            ['value' => 'A & B "quoted"'],
+            ['value' => 'Привет <мир> 😀'],
+        ])
+        ->and($xml->documentElement?->getAttribute('label'))
+        ->toBe('A & B "quoted"')
+        ->and($xml->getElementsByTagName('item')->item(0)?->textContent)
+        ->toBe('Привет <мир> 😀');
+});
+
+test('reports generated feed read failures with path context', function () {
+    $directory = (new TemporaryDirectory)->create();
+    $path      = $directory->path('missing.json');
+
+    try {
+        expect(fn () => readFeedFile($path))
+            ->toThrow(RuntimeException::class, "Unable to read generated feed file: [$path].");
+    } finally {
+        $directory->delete();
+    }
+});
+
+test('keeps JSON serialization exceptions with JSON Lines record context', function () {
+    $failure = null;
+
+    try {
+        parseJsonLines('{"id":1}' . "\n" . "{\"value\":\"\xB1\x31\"}");
+    } catch (RuntimeException $exception) {
+        $failure = $exception;
+    }
+
+    expect($failure)
+        ->toBeInstanceOf(RuntimeException::class)
+        ->and($failure?->getMessage())
+        ->toContain('Invalid JSON Lines record at line [2]:')
+        ->and($failure?->getPrevious())
+        ->toBeInstanceOf(JsonException::class);
+});


### PR DESCRIPTION
## Summary

- validate XML and RSS with DOMDocument and libxml error handling
- decode JSON with exceptions, parse every JSON Lines record independently, and parse CSV with fgetcsv
- verify decoded values for every split output part
- add malformed-format, special-character, filesystem, and serialization regression coverage

## Why

Snapshot equality could preserve malformed feed output. Several format assertions checked syntax incompletely or did not assert semantics.

## Impact

This is test-only hardening. Runtime APIs and generated feed output are unchanged. Validation failures now include file or record context.

## Checks

- `composer test`: 253 tests, 1282 assertions
- line coverage: 95.5%
- type coverage: 99.6%
- Pint
- `git diff --check`

Fixes #166