### PR TITLE
Prevent feed draft path collisions

### DIFF
--- a/.ai-factory/patches/2026-07-21-14.09.md
+++ b/.ai-factory/patches/2026-07-21-14.09.md
@@ -1,0 +1,29 @@
+# Draft path collisions during concurrent feed generation
+
+**Date:** 2026-07-21 14:09
+**Files:** src/Services/FilesystemService.php, tests/Unit/Services/FilesystemServiceTest.php, tests/Feature/Events/FailedTest.php
+**Severity:** high
+
+## Problem
+
+Concurrent feed generation could select an occupied draft directory or file path and fail with `PathAlreadyExists`, `mkdir(): File exists`, or `OpenFeedException`. Failure cleanup could also remove drafts belonging to another operation when several drafts shared one parent directory.
+
+## Root Cause
+
+Draft paths were historically derived from the output filename and timestamp precision. A later random suffix reduced the probability of collision but did not retry occupied candidates. Directory creation still used a separate existence check followed by `mkdir()`, and drafts created in a supplied directory did not own an isolated cleanup boundary.
+
+## Solution
+
+Draft and staging names now use filename-independent 128-bit random identifiers. Every draft owns a unique child directory and an exclusively created file. Directory creation uses an atomic `mkdir()` attempt with a bounded retry for occupied candidates, while non-collision failures stop immediately. Publication locking remains keyed separately by the normalized output path, and failure cleanup removes only the current operation's draft or staging directory.
+
+## Prevention
+
+- Keep temporary resource identity independent from public output names.
+- Use atomic creation as the collision check instead of check-then-create sequences.
+- Retry only occupied candidates and preserve colliding resources.
+- Give every concurrent operation an exclusive cleanup boundary.
+- Test collisions with deterministic identifier sequences instead of timestamp timing or probabilistic stress loops.
+
+## Tags
+
+`#filesystem` `#concurrency` `#race-condition` `#draft` `#cleanup` `#php`

--- a/src/Services/FilesystemService.php
+++ b/src/Services/FilesystemService.php
@@ -11,7 +11,6 @@ use DragonCode\LaravelFeed\Exceptions\ResourceMetaException;
 use DragonCode\LaravelFeed\Exceptions\WriteFeedException;
 use Illuminate\Filesystem\Filesystem as File;
 use Illuminate\Filesystem\LockableFile;
-use Illuminate\Support\Str;
 use RuntimeException;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
 use Throwable;
@@ -42,9 +41,12 @@ use function stream_get_meta_data;
 use function strlen;
 use function strtolower;
 use function substr;
+use function sys_get_temp_dir;
 
 class FilesystemService
 {
+    protected const MAX_PATH_ATTEMPTS = 10;
+
     public function __construct(
         protected File $file,
     ) {}
@@ -52,22 +54,39 @@ class FilesystemService
     /** @return resource */
     public function createDraft(string $filename, ?string $directory = null) // @pest-ignore-type
     {
-        $temp = $this->draftPath($filename, $directory);
+        $temp    = $filename;
+        $cleanup = false;
 
         try {
-            $resource = fopen($temp, 'xb');
+            for ($attempt = 0; $attempt < self::MAX_PATH_ATTEMPTS; $attempt++) {
+                $temp     = $this->draftPath($filename, $directory);
+                $cleanup  = true;
+                $resource = @fopen($temp, 'xb');
 
-            if ($resource === false) {
-                // @codeCoverageIgnoreStart
-                throw new RuntimeException('Unable to open resource for writing.');
-                // @codeCoverageIgnoreEnd
+                if ($resource !== false) {
+                    return $resource;
+                }
+
+                $collision = $this->file->exists($temp);
+
+                $this->cleanTemporaryDirectory($temp);
+
+                $cleanup = false;
+
+                if (! $collision) {
+                    throw new RuntimeException('Unable to open resource for writing.');
+                }
             }
 
-            return $resource;
-            // @codeCoverageIgnoreStart
+            throw new RuntimeException(
+                'Unable to create a unique feed draft after [' . self::MAX_PATH_ATTEMPTS . '] attempts.'
+            );
         } catch (Throwable $e) {
+            if ($cleanup) {
+                $this->cleanTemporaryDirectory($temp);
+            }
+
             throw new OpenFeedException($temp, $e);
-            // @codeCoverageIgnoreEnd
         }
     }
 
@@ -280,10 +299,10 @@ class FilesystemService
         try {
             $this->file->ensureDirectoryExists(dirname($path));
 
-            return (new TemporaryDirectory)
-                ->location(dirname($path))
-                ->name('.feeds_staging_' . bin2hex(random_bytes(16)))
-                ->create();
+            return $this->createTemporaryDirectory(
+                dirname($path),
+                fn () => '.feeds_staging_' . $this->uniqueIdentifier()
+            );
         } catch (Throwable $e) {
             throw new OpenFeedException($path, $e);
         }
@@ -291,14 +310,39 @@ class FilesystemService
 
     protected function draftPath(string $filename, ?string $directory = null): string
     {
-        if ($directory !== null) {
-            return $directory . DIRECTORY_SEPARATOR . $this->temporaryFilename($filename);
+        $draft = $this->createTemporaryDirectory(
+            $directory ?? sys_get_temp_dir(),
+            fn () => $this->temporaryFilename($filename)
+        );
+
+        try {
+            return $draft->path() . DIRECTORY_SEPARATOR . $this->temporaryFilename($filename);
+        } catch (Throwable $e) {
+            $draft->delete();
+
+            throw $e;
+        }
+    }
+
+    protected function createTemporaryDirectory(string $location, Closure $name): TemporaryDirectory
+    {
+        for ($attempt = 0; $attempt < self::MAX_PATH_ATTEMPTS; $attempt++) {
+            $directory = (new TemporaryDirectory)
+                ->location($location)
+                ->name($name());
+
+            if ($this->file->makeDirectory($directory->path(), 0o777, false, true)) {
+                return $directory;
+            }
+
+            if (! $this->file->exists($directory->path())) {
+                throw new RuntimeException("Unable to create the temporary directory: [{$directory->path()}].");
+            }
         }
 
-        return (new TemporaryDirectory)
-            ->name($this->temporaryFilename($filename))
-            ->create()
-            ->path($this->temporaryFilename($filename));
+        throw new RuntimeException(
+            'Unable to create a unique temporary directory after [' . self::MAX_PATH_ATTEMPTS . '] attempts.'
+        );
     }
 
     protected function isPublicationPath(string $path, string $publication): bool
@@ -410,11 +454,12 @@ class FilesystemService
 
     protected function temporaryFilename(string $filename): string
     {
-        return Str::of($filename)
-            ->prepend('feeds_draft_')
-            ->append('_', bin2hex(random_bytes(16)))
-            ->slug('_')
-            ->toString();
+        return 'feeds_draft_' . $this->uniqueIdentifier();
+    }
+
+    protected function uniqueIdentifier(): string
+    {
+        return bin2hex(random_bytes(16));
     }
 
     protected function validateDrafts(string $path, array $drafts): array

--- a/tests/.pest/snapshots/Feature/Events/FailedTest/failed_generation_removes_its_draft_and_preserves_another_staging_directory.snap
+++ b/tests/.pest/snapshots/Feature/Events/FailedTest/failed_generation_removes_its_draft_and_preserves_another_staging_directory.snap
@@ -1,0 +1,1 @@
+end of snapshots

--- a/tests/Feature/Events/FailedTest.php
+++ b/tests/Feature/Events/FailedTest.php
@@ -4,11 +4,51 @@ declare(strict_types=1);
 
 use DragonCode\LaravelFeed\Commands\FeedGenerateCommand;
 use DragonCode\LaravelFeed\Exceptions\FeedGenerationException;
+use DragonCode\LaravelFeed\Feeds\Feed as BaseFeed;
+use DragonCode\LaravelFeed\Feeds\Items\FeedItem;
 use DragonCode\LaravelFeed\Models\Feed;
+use DragonCode\LaravelFeed\Services\GeneratorService;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Event;
+use Spatie\TemporaryDirectory\TemporaryDirectory;
 use Workbench\App\Feeds\FailedFeed;
+use Workbench\App\Models\User;
 
 use function Pest\Laravel\artisan;
+
+final class FailedAfterDraftFeed extends BaseFeed
+{
+    public function builder(): Builder
+    {
+        return User::query();
+    }
+
+    public function filename(): string
+    {
+        return 'failed-after-draft.xml';
+    }
+
+    public function item(Model $model): FeedItem
+    {
+        return new FailedAfterDraftFeedItem($model);
+    }
+}
+
+final class FailedAfterDraftFeedItem extends FeedItem
+{
+    public static int $calls = 0;
+
+    public function toArray(): array
+    {
+        if (++self::$calls === 2) {
+            throw new RuntimeException('Generation failed after opening a draft.');
+        }
+
+        return parent::toArray();
+    }
+}
 
 test('failed', function () {
     Event::fake();
@@ -41,5 +81,40 @@ test('feed class link', function () {
     } catch (FeedGenerationException $e) {
         expect($e->getMessage())->toContain('Something went wrong while generating the feed.');
         expect($e->getFeed())->toBe(FailedFeed::class);
+    }
+});
+
+test('failed generation removes its draft and preserves another staging directory', function () {
+    Event::fake();
+
+    FailedAfterDraftFeedItem::$calls = 0;
+
+    $feed       = app(FailedAfterDraftFeed::class);
+    $filesystem = new Filesystem;
+    $directory  = dirname($feed->path());
+
+    $filesystem->ensureDirectoryExists($directory);
+
+    $foreign = (new TemporaryDirectory)
+        ->location($directory)
+        ->name('.feeds_staging_foreign')
+        ->create();
+    $sentinel = $foreign->path('sentinel.txt');
+
+    file_put_contents($sentinel, 'foreign');
+
+    try {
+        expect(fn () => app(GeneratorService::class)->feed($feed))
+            ->toThrow(FeedGenerationException::class, 'Generation failed after opening a draft.');
+
+        expect($feed->path())
+            ->not->toBeFile()
+            ->and(file_get_contents($sentinel))
+            ->toBe('foreign')
+            ->and(glob($directory . DIRECTORY_SEPARATOR . '.feeds_staging_*'))
+            ->toBe([$foreign->path()]);
+    } finally {
+        $foreign->delete();
+        $filesystem->delete($feed->path());
     }
 });

--- a/tests/Unit/Services/FilesystemServiceTest.php
+++ b/tests/Unit/Services/FilesystemServiceTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use DragonCode\LaravelFeed\Exceptions\CloseFeedException;
+use DragonCode\LaravelFeed\Exceptions\OpenFeedException;
 use DragonCode\LaravelFeed\Exceptions\WriteFeedException;
 use DragonCode\LaravelFeed\Services\FilesystemService;
 use Illuminate\Contracts\Filesystem\LockTimeoutException;
@@ -67,6 +68,81 @@ final class ControlledMoveFilesystem extends Filesystem
         }
 
         return parent::move($path, $target);
+    }
+}
+
+final class ControlledDraftNameFilesystemService extends FilesystemService
+{
+    public static array $filenames = [];
+
+    public static function reset(string ...$filenames): void
+    {
+        self::$filenames = $filenames;
+    }
+
+    protected function temporaryFilename(string $filename): string
+    {
+        return array_shift(self::$filenames) ?? throw new LogicException('Missing controlled draft filename.');
+    }
+}
+
+final class ControlledIdentifierFilesystemService extends FilesystemService
+{
+    public static array $identifiers = [];
+
+    public static function reset(string ...$identifiers): void
+    {
+        self::$identifiers = $identifiers;
+    }
+
+    protected function uniqueIdentifier(): string
+    {
+        return array_shift(self::$identifiers) ?? throw new LogicException('Missing controlled identifier.');
+    }
+}
+
+final class ControlledDraftCollisionFilesystemService extends FilesystemService
+{
+    protected int $attempt = 0;
+
+    protected ?string $directoryName = null;
+
+    public function __construct(
+        Filesystem $file,
+        protected string $location,
+        protected int $collisions,
+    ) {
+        parent::__construct($file);
+    }
+
+    protected function temporaryFilename(string $filename): string
+    {
+        if ($this->directoryName === null) {
+            return $this->directoryName = 'feeds_draft_directory_' . $this->attempt;
+        }
+
+        $filename = 'feeds_draft_file_' . $this->attempt++;
+
+        if ($this->collisions > 0) {
+            file_put_contents(
+                $this->location . DIRECTORY_SEPARATOR . $this->directoryName . DIRECTORY_SEPARATOR . $filename,
+                'collision'
+            );
+
+            $this->collisions--;
+        }
+
+        $this->directoryName = null;
+
+        return $filename;
+    }
+}
+
+final class MissingDraftPathFilesystemService extends FilesystemService
+{
+    protected function draftPath(string $filename, ?string $directory = null): string
+    {
+        return $directory . DIRECTORY_SEPARATOR . 'missing' . DIRECTORY_SEPARATOR . 'feeds_draft_file';
     }
 }
 
@@ -166,6 +242,191 @@ test('creates collision-resistant drafts and cleans the staging directory', func
     }
 });
 
+test('retries draft creation when the generated path already exists', function () {
+    $directory = (new TemporaryDirectory)->create();
+    $collision = $directory->path() . DIRECTORY_SEPARATOR . 'feeds_draft_collision';
+    $sentinel  = $collision . DIRECTORY_SEPARATOR . 'sentinel.txt';
+
+    mkdir($collision);
+    file_put_contents($sentinel, 'existing');
+
+    ControlledDraftNameFilesystemService::reset(
+        'feeds_draft_collision',
+        'feeds_draft_directory',
+        'feeds_draft_file'
+    );
+
+    try {
+        $service   = new ControlledDraftNameFilesystemService(new Filesystem);
+        $draft     = $service->createDraft('feed.json', $directory->path());
+        $draftPath = $service->finishDraft($draft);
+
+        expect(basename(dirname($draftPath)))
+            ->toBe('feeds_draft_directory')
+            ->and(basename($draftPath))
+            ->toBe('feeds_draft_file')
+            ->and(file_get_contents($sentinel))
+            ->toBe('existing');
+    } finally {
+        $directory->delete();
+    }
+});
+
+test('retries exclusive draft file creation after a collision', function () {
+    $directory = (new TemporaryDirectory)->create();
+
+    try {
+        $service = new ControlledDraftCollisionFilesystemService(
+            new Filesystem,
+            $directory->path(),
+            1
+        );
+        $draft     = $service->createDraft('feed.json', $directory->path());
+        $draftPath = $service->finishDraft($draft);
+
+        expect(basename(dirname($draftPath)))
+            ->toBe('feeds_draft_directory_1')
+            ->and(basename($draftPath))
+            ->toBe('feeds_draft_file_1')
+            ->and($directory->path() . DIRECTORY_SEPARATOR . 'feeds_draft_directory_0')
+            ->not->toBeDirectory();
+    } finally {
+        $directory->delete();
+    }
+});
+
+test('stops retrying after repeated draft file collisions', function () {
+    $directory = (new TemporaryDirectory)->create();
+
+    try {
+        $service = new ControlledDraftCollisionFilesystemService(
+            new Filesystem,
+            $directory->path(),
+            10
+        );
+
+        expect(fn () => $service->createDraft('feed.json', $directory->path()))
+            ->toThrow(
+                OpenFeedException::class,
+                'Unable to create a unique feed draft after [10] attempts.'
+            )
+            ->and(glob($directory->path() . DIRECTORY_SEPARATOR . 'feeds_draft_directory_*'))
+            ->toBe([]);
+    } finally {
+        $directory->delete();
+    }
+});
+
+test('stops retrying after repeated draft directory collisions', function () {
+    $directory = (new TemporaryDirectory)->create();
+    $collision = $directory->path() . DIRECTORY_SEPARATOR . 'feeds_draft_collision';
+    $sentinel  = $collision . DIRECTORY_SEPARATOR . 'sentinel.txt';
+
+    mkdir($collision);
+    file_put_contents($sentinel, 'existing');
+
+    ControlledDraftNameFilesystemService::reset(
+        ...array_fill(0, 10, 'feeds_draft_collision')
+    );
+
+    try {
+        $service = new ControlledDraftNameFilesystemService(new Filesystem);
+
+        expect(fn () => $service->createDraft('feed.json', $directory->path()))
+            ->toThrow(
+                OpenFeedException::class,
+                'Unable to create a unique temporary directory after [10] attempts.'
+            )
+            ->and(file_get_contents($sentinel))
+            ->toBe('existing');
+    } finally {
+        $directory->delete();
+    }
+});
+
+test('removes an allocated draft directory when filename generation fails', function () {
+    $directory = (new TemporaryDirectory)->create();
+
+    ControlledDraftNameFilesystemService::reset('feeds_draft_directory');
+
+    try {
+        $service = new ControlledDraftNameFilesystemService(new Filesystem);
+
+        expect(fn () => $service->createDraft('feed.json', $directory->path()))
+            ->toThrow(OpenFeedException::class, 'Missing controlled draft filename.')
+            ->and($directory->path() . DIRECTORY_SEPARATOR . 'feeds_draft_directory')
+            ->not->toBeDirectory();
+    } finally {
+        $directory->delete();
+    }
+});
+
+test('does not retry draft creation after a non-collision failure', function () {
+    $directory = (new TemporaryDirectory)->create();
+
+    try {
+        $service = new MissingDraftPathFilesystemService(new Filesystem);
+
+        expect(fn () => $service->createDraft('feed.json', $directory->path()))
+            ->toThrow(OpenFeedException::class, 'Unable to open resource for writing.');
+    } finally {
+        $directory->delete();
+    }
+});
+
+test('keeps draft paths independent from output filenames', function () {
+    $directory = (new TemporaryDirectory)->create();
+    $service   = new FilesystemService(new Filesystem);
+
+    try {
+        $draft     = $service->createDraft('private-catalog.json', $directory->path());
+        $draftPath = $service->finishDraft($draft);
+
+        expect(basename(dirname($draftPath)))
+            ->toMatch('/^feeds_draft_[a-f0-9]{32}$/')
+            ->and(basename($draftPath))
+            ->toMatch('/^feeds_draft_[a-f0-9]{32}$/')
+            ->and($draftPath)
+            ->not->toContain('private_catalog');
+    } finally {
+        $directory->delete();
+    }
+});
+
+test('retries staging creation without removing the colliding directory', function () {
+    $directory = (new TemporaryDirectory)->create();
+    $path      = $directory->path('feed.json');
+    $collision = $directory->path() . DIRECTORY_SEPARATOR . '.feeds_staging_collision';
+    $sentinel  = $collision . DIRECTORY_SEPARATOR . 'sentinel.txt';
+
+    mkdir($collision);
+    file_put_contents($sentinel, 'existing');
+
+    ControlledIdentifierFilesystemService::reset('collision', 'staging', 'draft_directory', 'draft_file');
+
+    try {
+        $service = new ControlledIdentifierFilesystemService(new Filesystem);
+
+        $service->publish($path, function (string $staging) use ($path, $service) {
+            expect(basename($staging))->toBe('.feeds_staging_staging');
+
+            $draft = $service->createDraft('feed.json', $staging);
+            $service->append($draft, 'published', $path);
+
+            return [$path => $service->finishDraft($draft)];
+        });
+
+        expect(file_get_contents($path))
+            ->toBe('published')
+            ->and(file_get_contents($sentinel))
+            ->toBe('existing')
+            ->and(glob($directory->path() . DIRECTORY_SEPARATOR . '.feeds_staging_*'))
+            ->toBe([$collision]);
+    } finally {
+        $directory->delete();
+    }
+});
+
 test('prevents overlapping publication for the same feed', function () {
     $directory = (new TemporaryDirectory)->create();
     $path      = $directory->path('feed.json');
@@ -223,12 +484,15 @@ test('restores every published part when a staged move fails', function () {
 test('release restores the published feed and cleans its draft when move fails', function () {
     $directory   = (new TemporaryDirectory)->create();
     $publication = $directory->path('feed.json');
+    $drafts      = $directory->path('drafts');
+    $foreign     = $drafts . DIRECTORY_SEPARATOR . 'foreign-draft';
     $file        = new ControlledMoveFilesystem;
     $service     = new FilesystemService($file);
-    $draft       = $service->createDraft('feed.json', $directory->path('drafts'));
+    $draft       = $service->createDraft('feed.json', $drafts);
     $draftPath   = stream_get_meta_data($draft)['uri'];
 
     file_put_contents($publication, 'old');
+    file_put_contents($foreign, 'foreign');
 
     $service->append($draft, 'new', $publication);
     $file->failNextMoveTo($publication);
@@ -239,7 +503,9 @@ test('release restores the published feed and cleans its draft when move fails',
             ->and(file_get_contents($publication))
             ->toBe('old')
             ->and(dirname($draftPath))
-            ->not->toBeDirectory();
+            ->not->toBeDirectory()
+            ->and(file_get_contents($foreign))
+            ->toBe('foreign');
     } finally {
         $directory->delete();
     }


### PR DESCRIPTION
## Summary

- generate staging directories, draft directories, and draft files from filename-independent 128-bit random identifiers
- retry occupied path candidates atomically with a bounded attempt limit
- isolate draft and staging cleanup so a failed generation cannot remove another operation's files
- add deterministic coverage for directory, file, and staging collisions plus failure cleanup

## Root cause

Draft paths were historically coupled to the output filename and timestamp precision. A later random suffix reduced the collision probability but still performed a single attempt, while directory creation retained a check-then-create race. Drafts created under a shared parent also lacked an exclusive cleanup boundary.

## Impact

Concurrent generation for the same filename now uses independent temporary paths while publication remains serialized by the existing per-output lock. Occupied candidates are preserved and retried, and abandoned drafts are removed without touching another process's staging data.

## Validation

- regression check failed before the fix and passed afterward
- 262 tests and 1313 assertions passed
- parallel code coverage passed at 95.8% with 16 processes
- type coverage passed at 99.6%
- Pint, PHP 8.2 syntax checks, and `git diff --check` passed

Closes #167