### PR TITLE
Fix tests modifying tracked documentation snippets

### DIFF
--- a/.ai-factory/patches/2026-07-21-15.10-stop-tests-from-modifying-docs-snippets.md
+++ b/.ai-factory/patches/2026-07-21-15.10-stop-tests-from-modifying-docs-snippets.md
@@ -1,0 +1,29 @@
+# Documentation tests modified tracked snippets
+
+**Date:** 2026-07-21
+**Severity:** Medium
+**Files:** `.gitattributes`, `composer.json`, `tests/Pest.php`, `tests/Helpers/docs.php`, `tests/Unit/DocsTest.php`, `docs/snippets/*.xml`
+
+## Problem
+
+Documentation tests generated files directly in the tracked `docs/snippets` directory. Successful and failing runs could leave the working tree modified. Cleanup depended on a Composer post-step that invoked Git, so package archives without `.git` could not run the suite reliably. Platform-specific line endings could also produce false differences.
+
+## Root Cause
+
+The tracked documentation directory was used as the generation workspace. Generated PHP snippets were formatted in place, XML snippets contained non-deterministic fixture data, and the only restoration mechanism ran after the test process completed. A failed process skipped that restoration.
+
+## Solution
+
+Documentation tests now generate snippets in a unique temporary workspace. The public filesystem is redirected there for each test. Generated files are formatted and compared with tracked snippets after LF normalization, while tracked files remain read-only during normal runs. `LARAVEL_FEEDS_UPDATE_DOCS=1` enables the explicit update path used by `composer test:update`. Fixture data is deterministic, cleanup always runs in `finally`, Git-based restoration was removed, and repository text files are normalized to LF.
+
+## Prevention
+
+- Generate test artifacts outside tracked directories.
+- Keep snapshot updates behind an explicit command.
+- Compare normalized content without rewriting expected files.
+- Clean temporary workspaces in `finally` on success and failure.
+- Cover comparison, update, cleanup, parallel execution, and source archives without `.git`.
+
+## Tags
+
+`tests`, `documentation`, `snapshots`, `filesystem`, `cross-platform`, `issue-168`

--- a/.ai-factory/patches/2026-07-21-15.48-stabilize-docs-faker-across-php.md
+++ b/.ai-factory/patches/2026-07-21-15.48-stabilize-docs-faker-across-php.md
@@ -1,0 +1,27 @@
+# Documentation fixtures differed on PHP 8.2
+
+**Date:** 2026-07-21
+**Severity:** Medium
+**Files:** `tests/Helpers/docs.php`, `tests/Unit/DocsTest.php`
+
+## Problem
+
+The PHP 8.2 and Laravel 11 CI job generated six documentation snippets with fixture values that differed from the tracked snippets. The same tests passed on newer PHP versions.
+
+## Root Cause
+
+Faker selects the legacy `MT_RAND_PHP` mode below PHP 8.3 and `MT_RAND_MT19937` on PHP 8.3 and newer. Calling `fake()->seed(168)` therefore produced different deterministic sequences across supported PHP versions.
+
+## Solution
+
+Documentation fixtures now initialize Faker and seed the global generator explicitly with `MT_RAND_MT19937`. A regression test verifies the expected Faker sequence independently of the running PHP version.
+
+## Prevention
+
+- Pin the random number generator algorithm when deterministic fixtures must be portable.
+- Exercise deterministic fixture generation on every supported PHP version.
+- Keep a direct regression assertion for the shared Faker sequence.
+
+## Tags
+
+`tests`, `documentation`, `faker`, `php-8.2`, `ci`, `issue-168`

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-* text=auto
+* text=auto eol=lf
 
 .ai/ export-ignore
 

--- a/composer.json
+++ b/composer.json
@@ -84,19 +84,14 @@
         "clear": "@php vendor/bin/testbench package:purge-skeleton --ansi",
         "migrate": "@php vendor/bin/testbench migrate:fresh --seed --ansi",
         "prepare": "@php vendor/bin/testbench package:discover --ansi",
-        "reset:snippets": "git restore --source=HEAD -- ./docs/snippets/*.xml",
         "style": "@php vendor/bin/pint --parallel --ansi",
-        "style:snippets": "@php vendor/bin/pint --dirty --ansi docs/snippets",
-        "test": [
-            "@php vendor/bin/pest --colors=always",
-            "@style:snippets",
-            "@reset:snippets"
-        ],
+        "style:snippets": "@php vendor/bin/pint --ansi docs/snippets",
+        "test": "@php vendor/bin/pest --colors=always",
         "test:coverage": "@php vendor/bin/pest --colors=always --coverage --compact --parallel --min=95",
         "test:type": "@php vendor/bin/pest --type-coverage --compact --min=95",
         "test:update": [
-            "@php vendor/bin/pest --colors=always --update-snapshots",
-            "@style:snippets"
+            "@putenv LARAVEL_FEEDS_UPDATE_DOCS=1",
+            "@php vendor/bin/pest --colors=always --update-snapshots"
         ]
     }
 }

--- a/docs/snippets/advanced-directive-array.xml
+++ b/docs/snippets/advanced-directive-array.xml
@@ -2,18 +2,18 @@
 <array_directive>
 
 <user>
-  <name>German Zulauf V</name>
-  <avatar>https://via.placeholder.com/640x480.png/00ddbb?text=quae</avatar>
-  <avatar>https://via.placeholder.com/640x480.png/00aa44?text=est</avatar>
-  <images name="sunt sapiente consectetur">https://via.placeholder.com/640x480.png/007799?text=tempore</images>
-  <images name="nulla nam fugiat">https://via.placeholder.com/640x480.png/000055?text=earum</images>
+  <name>User 1</name>
+  <avatar>https://via.placeholder.com/640x480.png/00ffff?text=aut</avatar>
+  <avatar>https://via.placeholder.com/640x480.png/0022dd?text=et</avatar>
+  <images name="doloremque distinctio facere">https://via.placeholder.com/640x480.png/0099dd?text=ea</images>
+  <images name="fuga odio expedita">https://via.placeholder.com/640x480.png/00cc77?text=sint</images>
 </user>
 <user>
-  <name>Miss Marisol Cummerata V</name>
-  <avatar>https://via.placeholder.com/640x480.png/009977?text=quaerat</avatar>
-  <avatar>https://via.placeholder.com/640x480.png/00ffaa?text=consequuntur</avatar>
-  <images name="at voluptates explicabo">https://via.placeholder.com/640x480.png/00ccaa?text=mollitia</images>
-  <images name="suscipit earum aut">https://via.placeholder.com/640x480.png/003333?text=aspernatur</images>
+  <name>User 2</name>
+  <avatar>https://via.placeholder.com/640x480.png/00ff99?text=est</avatar>
+  <avatar>https://via.placeholder.com/640x480.png/003300?text=non</avatar>
+  <images name="distinctio et aliquam">https://via.placeholder.com/640x480.png/0099aa?text=accusantium</images>
+  <images name="consequatur soluta nemo">https://via.placeholder.com/640x480.png/0099cc?text=ab</images>
 </user>
 
 </array_directive>

--- a/docs/snippets/advanced-directive-attributes.xml
+++ b/docs/snippets/advanced-directive-attributes.xml
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <attributes_directive>
 
-<company since="1987"/>
+<company since="1994"/>
 <url>https://example.com</url>
 
 <user>
-  <name>Briana Pollich</name>
-  <contact email="olaf.crooks@example.com" phone="555-000-1"/>
+  <name>User 1</name>
+  <contact email="user1@example.com" phone="555-000-1"/>
 </user>
 <user>
-  <name>Melissa Bahringer Jr.</name>
-  <contact email="bridie.padberg@example.com" phone="555-000-2"/>
+  <name>User 2</name>
+  <contact email="user2@example.com" phone="555-000-2"/>
 </user>
 
 </attributes_directive>

--- a/docs/snippets/advanced-directive-cdata.xml
+++ b/docs/snippets/advanced-directive-cdata.xml
@@ -2,12 +2,12 @@
 <cdata_directive>
 
 <user>
-  <name><![CDATA[<h1>Mrs. Mina Kirlin</h1>]]></name>
-  <email>labadie.stefan@example.net</email>
+  <name><![CDATA[<h1>User 1</h1>]]></name>
+  <email>user1@example.com</email>
 </user>
 <user>
-  <name><![CDATA[<h1>Mark Weber DVM</h1>]]></name>
-  <email>laurel52@example.org</email>
+  <name><![CDATA[<h1>User 2</h1>]]></name>
+  <email>user2@example.com</email>
 </user>
 
 </cdata_directive>

--- a/docs/snippets/advanced-directive-mixed.xml
+++ b/docs/snippets/advanced-directive-mixed.xml
@@ -2,17 +2,17 @@
 <mixed_directive>
 
 <user>
-  <name>Miss Freeda Daniel III</name>
+  <name>User 1</name>
   <some>
     <first>Foo</first>
-    <second>qrobel@example.org</second>
+    <second>user1@example.com</second>
 </some>
 </user>
 <user>
-  <name>Mr. Joshuah Ernser MD</name>
+  <name>User 2</name>
   <some>
     <first>Foo</first>
-    <second>shayna.hayes@example.net</second>
+    <second>user2@example.com</second>
 </some>
 </user>
 

--- a/docs/snippets/advanced-directive-value.xml
+++ b/docs/snippets/advanced-directive-value.xml
@@ -2,12 +2,12 @@
 <value_directive>
 
 <user>
-  <name>Prof. Kristoffer Monahan DDS</name>
-  <contact type="email">dexter07@example.net</contact>
+  <name>User 1</name>
+  <contact type="email">user1@example.com</contact>
 </user>
 <user>
-  <name>Nikko Lesch</name>
-  <contact type="email">homenick.dennis@example.net</contact>
+  <name>User 2</name>
+  <contact type="email">user2@example.com</contact>
 </user>
 
 </value_directive>

--- a/docs/snippets/advanced-element-attribute.xml
+++ b/docs/snippets/advanced-element-attribute.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <attribute>
 
-<user created_at="2026-03-19T23:34:44+00:00">
+<user created_at="2025-09-04T04:08:12+00:00">
   <id>1</id>
-  <name>Prof. Dillan Lockman III</name>
+  <name>User 1</name>
 </user>
-<user created_at="2026-03-19T23:34:44+00:00">
+<user created_at="2025-09-04T04:08:12+00:00">
   <id>2</id>
-  <name>Prof. Kristofer Borer</name>
+  <name>User 2</name>
 </user>
 
 </attribute>

--- a/docs/snippets/advanced-element-header-footer.xml
+++ b/docs/snippets/advanced-element-header-footer.xml
@@ -3,11 +3,11 @@
 
 <user>
   <id>1</id>
-  <name>Dorcas Kirlin Jr.</name>
+  <name>User 1</name>
 </user>
 <user>
   <id>2</id>
-  <name>Dr. Dewayne Cormier</name>
+  <name>User 2</name>
 </user>
 
 </header_footer>

--- a/docs/snippets/advanced-element-info-before-false.xml
+++ b/docs/snippets/advanced-element-info-before-false.xml
@@ -6,11 +6,11 @@
 
 <user>
   <id>1</id>
-  <name>Mr. Judson Stokes MD</name>
+  <name>User 1</name>
 </user>
 <user>
   <id>2</id>
-  <name>Dr. Trenton Collins</name>
+  <name>User 2</name>
 </user>
 
 </info_method>

--- a/docs/snippets/advanced-element-info.xml
+++ b/docs/snippets/advanced-element-info.xml
@@ -6,11 +6,11 @@
 
 <user>
   <id>1</id>
-  <name>Mafalda Zulauf</name>
+  <name>User 1</name>
 </user>
 <user>
   <id>2</id>
-  <name>Dr. Ahmad Cummerata IV</name>
+  <name>User 2</name>
 </user>
 
 </info_method>

--- a/docs/snippets/advanced-element-root.xml
+++ b/docs/snippets/advanced-element-root.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<foo count="2" generated_at="2025-09-04 04:08:12">
+<foo count="2" generated_at="2025-09-04T04:08:12+00:00">
 
 <user>
   <id>1</id>
-  <name>Jaime Lesch PhD</name>
+  <name>User 1</name>
 </user>
 <user>
   <id>2</id>
-  <name>Bert Kuhn</name>
+  <name>User 2</name>
 </user>
 
 </foo>

--- a/docs/snippets/receipt-instagram-feed.xml
+++ b/docs/snippets/receipt-instagram-feed.xml
@@ -8,7 +8,7 @@
   <g:id>1</g:id>
   <g:title><![CDATA[Some 1]]></g:title>
   <g:description><![CDATA[Some description 1]]></g:description>
-  <g:link>https://example.com/products/debitis-fuga-possimus-et</g:link>
+  <g:link>https://example.com/products/ea-voluptatum-fuga-odio-expedita</g:link>
   <g:image_link>https://via.placeholder.com/640x480.png/008877?text=repudiandae</g:image_link>
   <g:additional_image_link>https://via.placeholder.com/640x480.png/008877?text=repudiandae</g:additional_image_link>
   <g:brand>The Best</g:brand>
@@ -31,7 +31,7 @@
   <g:id>2</g:id>
   <g:title><![CDATA[Some 2]]></g:title>
   <g:description><![CDATA[Some description 2]]></g:description>
-  <g:link>https://example.com/products/aliquam-distinctio-eius-blanditiis-libero-qui-nostrum</g:link>
+  <g:link>https://example.com/products/dolores-rerum-ut-consequatur-in</g:link>
   <g:image_link>https://via.placeholder.com/640x480.png/009966?text=beatae</g:image_link>
   <g:additional_image_link>https://via.placeholder.com/640x480.png/009966?text=beatae</g:additional_image_link>
   <g:additional_image_link>https://via.placeholder.com/640x480.png/000011?text=deleniti</g:additional_image_link>

--- a/docs/snippets/receipt-rss-feed.xml
+++ b/docs/snippets/receipt-rss-feed.xml
@@ -8,7 +8,7 @@
   <guid>1</guid>
   <description><![CDATA[Some content 1]]></description>
   <category>Some category 1</category>
-  <pubDate>Thu, 04 Sep 2025 03:43:47 +0000</pubDate>
+  <pubDate>Wed, 03 Sep 2025 22:35:34 +0000</pubDate>
   <foo>bar</foo>
 </item>
 <item>
@@ -17,7 +17,7 @@
   <guid>2</guid>
   <description><![CDATA[Some content 2]]></description>
   <category>Some category 2</category>
-  <pubDate>Thu, 04 Sep 2025 00:33:59 +0000</pubDate>
+  <pubDate>Thu, 04 Sep 2025 02:44:27 +0000</pubDate>
   <foo>bar</foo>
 </item>
 <item>
@@ -26,7 +26,7 @@
   <guid>3</guid>
   <description><![CDATA[Some content 3]]></description>
   <category>Some category 3</category>
-  <pubDate>Wed, 03 Sep 2025 11:17:26 +0000</pubDate>
+  <pubDate>Thu, 04 Sep 2025 01:06:18 +0000</pubDate>
   <foo>bar</foo>
 </item>
 

--- a/docs/snippets/receipt-sitemap-feed.xml
+++ b/docs/snippets/receipt-sitemap-feed.xml
@@ -2,12 +2,12 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9">
 
 <url>
-  <loc>https://example.com/products/assumenda-quia-et-et-hic-iusto-nesciunt</loc>
+  <loc>https://example.com/products/ea-voluptatum-fuga-odio-expedita</loc>
   <lastmod>2025-08-31T20:00:00+00:00</lastmod>
   <priority>0.9</priority>
 </url>
 <url>
-  <loc>https://example.com/products/excepturi-ea-molestiae-voluptas-et-labore-voluptas</loc>
+  <loc>https://example.com/products/dolores-rerum-ut-consequatur-in</loc>
   <lastmod>2025-08-30T19:00:00+00:00</lastmod>
   <priority>0.9</priority>
 </url>

--- a/docs/snippets/receipt-yandex-feed.xml
+++ b/docs/snippets/receipt-yandex-feed.xml
@@ -18,7 +18,7 @@
 <offers>
 
 <offer id="1" available="true" type="vendor.model">
-  <url>https://example.com/products/inventore-nostrum-et-magnam-distinctio-qui-vero</url>
+  <url>https://example.com/products/ea-voluptatum-fuga-odio-expedita</url>
   <barcode>GD-PRDCT-1</barcode>
   <name>Some 1</name>
   <description>Some description 1</description>
@@ -29,7 +29,7 @@
   <foo>bar</foo>
 </offer>
 <offer id="2" available="true" type="vendor.model">
-  <url>https://example.com/products/qui-nulla-et-quia-deleniti-animi-aliquam-ex</url>
+  <url>https://example.com/products/dolores-rerum-ut-consequatur-in</url>
   <barcode>GD-PRDCT-2</barcode>
   <name>Some 2</name>
   <description>Some description 2</description>

--- a/tests/Helpers/docs.php
+++ b/tests/Helpers/docs.php
@@ -69,7 +69,7 @@ function configureDocsWorkspace(): void
 
 function stabilizeDocsFixtures(): void
 {
-    fake()->seed(168);
+    stabilizeDocsFaker();
 
     foreach (User::query()->orderBy('id')->get() as $index => $user) {
         $number = $index + 1;
@@ -81,6 +81,13 @@ function stabilizeDocsFixtures(): void
             'updated_at' => getDefaultDateTime(),
         ])->saveQuietly();
     }
+}
+
+function stabilizeDocsFaker(): void
+{
+    fake();
+
+    mt_srand(168, MT_RAND_MT19937);
 }
 
 function finishDocsWorkspace(?bool $update = null): void

--- a/tests/Helpers/docs.php
+++ b/tests/Helpers/docs.php
@@ -2,12 +2,17 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Facades\Storage;
+use Spatie\TemporaryDirectory\TemporaryDirectory;
+use Symfony\Component\Process\Process;
+use Workbench\App\Models\User;
+
 use function Orchestra\Testbench\workbench_path;
 
 function copyFeedFileToDoc(string $source, string $target, array $replaces = [], bool $cutFilename = true): void
 {
     $sourceFile = workbench_path('app/Feeds/Docs/' . $source . '.php');
-    $targetFile = __DIR__ . '/../../docs/snippets/' . $target;
+    $targetFile = docsGeneratedPath($target);
 
     $content = file_get_contents($sourceFile);
 
@@ -32,4 +37,261 @@ function copyFeedFileToDoc(string $source, string $target, array $replaces = [],
     }
 
     file_put_contents($targetFile, $content);
+}
+
+function createDocsWorkspace(): void
+{
+    deleteDocsWorkspace();
+
+    $workspace = (new TemporaryDirectory)
+        ->deleteWhenDestroyed()
+        ->create();
+
+    $GLOBALS['laravelFeedsDocsWorkspace'] = $workspace;
+
+    docsDebug('Workspace created.', ['path' => $workspace->path()]);
+}
+
+function configureDocsWorkspace(): void
+{
+    $root = docsWorkspace()->path(
+        implode(DIRECTORY_SEPARATOR, array_fill(0, 9, 'storage'))
+    );
+
+    Storage::set('public', Storage::build([
+        'driver' => 'local',
+        'root'   => $root,
+        'throw'  => true,
+    ]));
+
+    docsDebug('Filesystem redirected.', ['root' => $root]);
+}
+
+function stabilizeDocsFixtures(): void
+{
+    fake()->seed(168);
+
+    foreach (User::query()->orderBy('id')->get() as $index => $user) {
+        $number = $index + 1;
+
+        $user->forceFill([
+            'name'       => 'User ' . $number,
+            'email'      => 'user' . $number . '@example.com',
+            'created_at' => getDefaultDateTime(),
+            'updated_at' => getDefaultDateTime(),
+        ])->saveQuietly();
+    }
+}
+
+function finishDocsWorkspace(?bool $update = null): void
+{
+    if (! hasDocsWorkspace()) {
+        return;
+    }
+
+    try {
+        $generated = docsGeneratedDirectory();
+        $tracked   = docsTrackedDirectory();
+
+        formatDocsDirectory($generated);
+
+        if ($update ?? shouldUpdateDocs()) {
+            updateDocsDirectory($generated, $tracked);
+        } else {
+            compareDocsDirectory($generated, $tracked);
+        }
+    } finally {
+        deleteDocsWorkspace();
+    }
+}
+
+function deleteDocsWorkspace(): void
+{
+    if (! hasDocsWorkspace()) {
+        return;
+    }
+
+    $workspace = docsWorkspace();
+    $path      = $workspace->path();
+
+    unset($GLOBALS['laravelFeedsDocsWorkspace']);
+
+    if (! $workspace->delete()) {
+        throw new RuntimeException("Unable to delete documentation workspace: [$path].");
+    }
+
+    docsDebug('Workspace deleted.', ['path' => $path]);
+}
+
+function hasDocsWorkspace(): bool
+{
+    return ($GLOBALS['laravelFeedsDocsWorkspace'] ?? null) instanceof TemporaryDirectory;
+}
+
+function docsWorkspace(): TemporaryDirectory
+{
+    $workspace = $GLOBALS['laravelFeedsDocsWorkspace'] ?? null;
+
+    if (! $workspace instanceof TemporaryDirectory) {
+        throw new RuntimeException('Documentation workspace has not been created.');
+    }
+
+    return $workspace;
+}
+
+function docsWorkspacePath(): string
+{
+    return docsWorkspace()->path();
+}
+
+function docsGeneratedDirectory(): string
+{
+    return docsWorkspace()->path(
+        implode(DIRECTORY_SEPARATOR, ['docs', 'snippets'])
+    );
+}
+
+function docsGeneratedPath(string $filename): string
+{
+    return docsWorkspace()->path(
+        implode(DIRECTORY_SEPARATOR, ['docs', 'snippets', $filename])
+    );
+}
+
+function docsTrackedDirectory(): string
+{
+    return implode(DIRECTORY_SEPARATOR, [dirname(__DIR__, 2), 'docs', 'snippets']);
+}
+
+function compareDocsDirectory(string $generated, string $tracked): void
+{
+    foreach (docsFiles($generated) as $file) {
+        compareDocsSnippet(
+            $file,
+            $tracked . DIRECTORY_SEPARATOR . basename($file)
+        );
+    }
+}
+
+function compareDocsSnippet(string $generated, string $tracked): void
+{
+    $actual   = normalizeDocsSnippet(readDocsSnippet($generated));
+    $expected = normalizeDocsSnippet(readDocsSnippet($tracked));
+
+    if ($actual !== $expected) {
+        docsDebug('Snippet mismatch.', [
+            'generated' => $generated,
+            'tracked'   => $tracked,
+            'actual'    => $actual,
+            'expected'  => $expected,
+        ]);
+
+        throw new RuntimeException(
+            "Generated documentation snippet does not match [$tracked]. Run [composer test:update] to update it."
+        );
+    }
+
+    docsDebug('Snippet matched.', [
+        'generated' => $generated,
+        'tracked'   => $tracked,
+        'sha256'    => hash('sha256', $actual),
+    ]);
+}
+
+function updateDocsDirectory(string $generated, string $tracked): void
+{
+    foreach (docsFiles($generated) as $file) {
+        $target  = $tracked . DIRECTORY_SEPARATOR . basename($file);
+        $content = normalizeDocsSnippet(readDocsSnippet($file));
+
+        writeDocsSnippet($target, $content);
+
+        docsDebug('Snippet updated.', [
+            'generated' => $file,
+            'tracked'   => $target,
+            'sha256'    => hash('sha256', $content),
+        ]);
+    }
+}
+
+function formatDocsDirectory(string $directory): void
+{
+    $files = glob($directory . DIRECTORY_SEPARATOR . '*.php') ?: [];
+
+    if ($files === []) {
+        return;
+    }
+
+    sort($files, SORT_STRING);
+
+    $root = dirname(__DIR__, 2);
+
+    $process = new Process([
+        PHP_BINARY,
+        $root . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'pint',
+        '--config=' . $root . DIRECTORY_SEPARATOR . 'pint.json',
+        ...$files,
+    ], $root);
+
+    $process->setTimeout(null);
+
+    docsDebug('Formatting started.', ['files' => $files]);
+
+    $process->mustRun();
+
+    docsDebug('Formatting finished.', ['files' => $files]);
+}
+
+function docsFiles(string $directory): array
+{
+    $files = array_values(
+        array_filter(glob($directory . DIRECTORY_SEPARATOR . '*') ?: [], is_file(...))
+    );
+
+    sort($files, SORT_STRING);
+
+    return $files;
+}
+
+function readDocsSnippet(string $path): string
+{
+    $content = @file_get_contents($path);
+
+    if ($content === false) {
+        throw new RuntimeException("Unable to read documentation snippet: [$path].");
+    }
+
+    return $content;
+}
+
+function writeDocsSnippet(string $path, string $content): void
+{
+    if (@file_put_contents($path, $content) === false) {
+        throw new RuntimeException("Unable to write documentation snippet: [$path].");
+    }
+}
+
+function normalizeDocsSnippet(string $content): string
+{
+    return str_replace(["\r\n", "\r"], "\n", $content);
+}
+
+function shouldUpdateDocs(): bool
+{
+    return filter_var(getenv('LARAVEL_FEEDS_UPDATE_DOCS') ?: false, FILTER_VALIDATE_BOOL);
+}
+
+function docsDebug(string $message, array $context = []): void
+{
+    $level = strtolower((string) getenv('LOG_LEVEL'));
+
+    if ($level !== 'debug' && getenv('LARAVEL_FEEDS_DEBUG_DOCS') !== '1') {
+        return;
+    }
+
+    $data = $context === []
+        ? ''
+        : ' ' . json_encode($context, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+    fwrite(STDERR, '[FIX:168] ' . $message . $data . PHP_EOL);
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -23,10 +23,24 @@ pest()
         deleteMigrations();
     })
     ->afterEach(function () {
-        expect('end of snapshots')->toMatchSnapshot();
+        try {
+            expect('end of snapshots')->toMatchSnapshot();
+        } finally {
+            try {
+                finishDocsWorkspace();
+            } finally {
+                deleteOperations();
+                deleteMigrations();
+            }
+        }
+    });
 
-        deleteOperations();
-        deleteMigrations();
+pest()
+    ->in('Feature/Docs')
+    ->beforeEach(function () {
+        createDocsWorkspace();
+        configureDocsWorkspace();
+        stabilizeDocsFixtures();
     });
 
 pest()

--- a/tests/Unit/DocsTest.php
+++ b/tests/Unit/DocsTest.php
@@ -55,6 +55,17 @@ test('writes documentation updates with LF line endings', function () {
     }
 });
 
+test('stabilizes documentation Faker output across PHP versions', function () {
+    try {
+        stabilizeDocsFaker();
+
+        expect(fake()->randomElements(range(1, 10), 4))
+            ->toBe([2, 10, 8, 4]);
+    } finally {
+        mt_srand();
+    }
+});
+
 test('deletes the documentation workspace when comparison fails', function () {
     createDocsWorkspace();
 

--- a/tests/Unit/DocsTest.php
+++ b/tests/Unit/DocsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use Spatie\TemporaryDirectory\TemporaryDirectory;
+
+test('compares generated snippets with normalized line endings without rewriting tracked files', function () {
+    $directory = (new TemporaryDirectory)->create();
+    $generated = $directory->path(implode(DIRECTORY_SEPARATOR, ['generated', 'example.txt']));
+    $tracked   = $directory->path(implode(DIRECTORY_SEPARATOR, ['tracked', 'example.txt']));
+
+    file_put_contents($generated, "first\r\nsecond\r\n");
+    file_put_contents($tracked, "first\nsecond\n");
+
+    try {
+        compareDocsSnippet($generated, $tracked);
+
+        expect(file_get_contents($tracked))->toBe("first\nsecond\n");
+    } finally {
+        $directory->delete();
+    }
+});
+
+test('keeps tracked snippets unchanged when generated content differs', function () {
+    $directory = (new TemporaryDirectory)->create();
+    $generated = $directory->path(implode(DIRECTORY_SEPARATOR, ['generated', 'example.txt']));
+    $tracked   = $directory->path(implode(DIRECTORY_SEPARATOR, ['tracked', 'example.txt']));
+
+    file_put_contents($generated, "different\r\n");
+    file_put_contents($tracked, "tracked\n");
+
+    try {
+        expect(fn () => compareDocsSnippet($generated, $tracked))
+            ->toThrow(RuntimeException::class);
+
+        expect(file_get_contents($tracked))->toBe("tracked\n");
+    } finally {
+        $directory->delete();
+    }
+});
+
+test('writes documentation updates with LF line endings', function () {
+    $directory = (new TemporaryDirectory)->create();
+    $generated = $directory->path(implode(DIRECTORY_SEPARATOR, ['generated', 'example.txt']));
+    $tracked   = $directory->path(implode(DIRECTORY_SEPARATOR, ['tracked', 'example.txt']));
+
+    file_put_contents($generated, "first\r\nsecond\r\n");
+
+    try {
+        updateDocsDirectory(dirname($generated), dirname($tracked));
+
+        expect(file_get_contents($tracked))->toBe("first\nsecond\n");
+    } finally {
+        $directory->delete();
+    }
+});
+
+test('deletes the documentation workspace when comparison fails', function () {
+    createDocsWorkspace();
+
+    $workspace = docsWorkspacePath();
+
+    file_put_contents(
+        docsGeneratedPath('advanced-element-root.xml'),
+        'different'
+    );
+
+    try {
+        expect(fn () => finishDocsWorkspace(false))
+            ->toThrow(RuntimeException::class);
+
+        expect($workspace)->not->toBeDirectory();
+    } finally {
+        deleteDocsWorkspace();
+    }
+});


### PR DESCRIPTION
## Summary

- generate documentation snippets in a per-test temporary workspace
- compare generated files with tracked snippets without rewriting them during normal tests
- keep tracked updates behind `composer test:update`
- normalize generated content to LF and enforce LF through `.gitattributes`
- make documentation fixtures deterministic and add regression coverage
- remove the Git-based snippet restoration step

## Root cause

Documentation tests generated and formatted files directly inside `docs/snippets`. Cleanup ran as a Composer post-step through `git restore`, so a failed test could leave tracked files modified and source archives without `.git` could not run the suite reliably.

## Impact

Successful and failing test runs now clean their temporary workspace without changing tracked snippets. Explicit documentation updates remain available through `composer test:update`.

## Validation

- `composer test`: 266 tests, 1319 assertions
- documentation and regression tests: 18 tests, 34 assertions
- parallel documentation tests: 14 tests, 28 assertions
- `composer test:update`: exit code 0
- type coverage: 99.6%
- code coverage: 95.8%
- Pint and `git diff --check`
- full test suite from a source archive without `.git`
- successful and forced-failure runs leave tracked snippet hashes unchanged

Fixes #168