### PR TITLE
Test supported dependency bounds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,10 @@ updates:
             interval: daily
         labels:
             - dependabot
+    -
+        package-ecosystem: composer
+        directory: /
+        schedule:
+            interval: daily
+        labels:
+            - dependabot

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,24 @@ on:
     push:
 
 jobs:
+    validate:
+        runs-on: ubuntu-latest
+
+        name: Composer Validate
+
+        steps:
+            -   name: Checkout code
+                uses: actions/checkout@v7
+
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: 8.5
+                    coverage: none
+
+            -   name: Validate Composer configuration
+                run: composer validate --strict
+
     unit:
         runs-on: ubuntu-latest
 
@@ -31,6 +49,28 @@ jobs:
 
             -   name: Install dependencies
                 run: composer require --no-blocking --dev laravel/framework:^${{ matrix.laravel }}
+
+            -   name: Execute tests
+                run: composer test
+
+    lowest:
+        runs-on: ubuntu-latest
+
+        name: Lowest Dependencies
+
+        steps:
+            -   name: Checkout code
+                uses: actions/checkout@v7
+
+            -   name: Setup PHP
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: 8.2
+                    extensions: curl, mbstring, zip, pcntl, pdo, pdo_sqlite, iconv
+                    coverage: none
+
+            -   name: Install lowest supported dependencies
+                run: composer update --no-blocking --prefer-lowest --prefer-stable
 
             -   name: Execute tests
                 run: composer test

--- a/composer.json
+++ b/composer.json
@@ -28,17 +28,17 @@
         "illuminate/database": "^11.0 || ^12.0 || ^13.0",
         "illuminate/filesystem": "^11.0 || ^12.0 || ^13.0",
         "illuminate/support": "^11.0 || ^12.0 || ^13.0",
-        "laravel/prompts": ">=0.3.6",
+        "laravel/prompts": "^0.3.6",
         "spatie/temporary-directory": "^2.3"
     },
     "require-dev": {
         "dragon-code/codestyler": "^6.3",
         "dragon-code/laravel-deploy-operations": "^7.1",
         "mockery/mockery": "^1.6",
-        "orchestra/testbench": "^9.0 || ^10.0 || ^11.0",
-        "pestphp/pest": "^3.0 || ^4.0",
-        "pestphp/pest-plugin-laravel": "^3.0 || ^4.0",
-        "pestphp/pest-plugin-type-coverage": "^3.0 || ^4.0",
+        "orchestra/testbench": "^9.17 || ^10.0 || ^11.0",
+        "pestphp/pest": "^3.8.7 || ^4.0",
+        "pestphp/pest-plugin-laravel": "^3.2 || ^4.0",
+        "pestphp/pest-plugin-type-coverage": "^3.6.1 || ^4.0",
         "symfony/var-dumper": "^7.3 || ^8.0"
     },
     "minimum-stability": "stable",


### PR DESCRIPTION
## Summary

- Bound `laravel/prompts` to the tested 0.3 release line.
- Raise Testbench and Pest lower bounds to versions compatible with the current test bootstrap.
- Add strict Composer validation and a lowest-dependencies CI job.
- Enable Composer updates in Dependabot.

## Why

The previous `>=0.3.6` constraint allowed untested future major versions. CI also exercised only the highest dependency set, while the declared Testbench and Pest minimums could not run the current suite.

## Impact

Package consumers remain on the supported Prompts 0.3 line until a later major is tested explicitly. CI now verifies both dependency boundaries and receives Composer update proposals.

## Validation

- `composer validate --strict`
- `composer normalize --dry-run`
- Lowest PHP 8.2 dependency set: 222 passed, 45 incomplete, 1204 assertions
- Highest PHP 8.2 dependency set: 222 passed, 45 incomplete, 1204 assertions
- Workflow and Dependabot YAML parsing
- `git diff --check`

Closes #169