### PR TITLE
Harden GitHub Actions permissions and pin workflow dependencies

### DIFF
--- a/.github/workflows/code-style.yml
+++ b/.github/workflows/code-style.yml
@@ -3,10 +3,15 @@ name: Code Style
 on:
     push:
 
-permissions: write-all
+permissions: {}
 
 jobs:
     Checks:
-        uses: TheDragonCode/.github/.github/workflows/code-style.yml@main
+        permissions:
+            artifact-metadata: write
+            contents: write
+            pull-requests: write
+
+        uses: TheDragonCode/.github/.github/workflows/code-style.yml@114cea00473063594c1ac778a22344341c177a70
         with:
             node: false

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,9 +6,7 @@ on:
             - main
     workflow_dispatch:
 
-permissions:
-    id-token: write
-    pages: write
+permissions: {}
 
 env:
     COMPOSER_TOKEN: ${{ secrets.COMPOSER_TOKEN }}
@@ -27,22 +25,24 @@ env:
 jobs:
     build:
         name: Build application
+        permissions:
+            contents: read
         runs-on: ubuntu-latest
 
         steps:
-            -   uses: actions/checkout@v7
+            -   uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
                 with:
                     fetch-depth: 0
 
             -   name: Build documentation
-                uses: JetBrains/writerside-github-action@v4
+                uses: JetBrains/writerside-github-action@738910d7cf197d67188300d0e0f84b2e708db3cf
                 with:
                     instance: ${{ env.INSTANCE }}
                     artifact: ${{ env.ARTIFACT_DOCS }}
                     docker-version: ${{ env.BUILDER_VERSION }}
 
             -   name: Upload artifacts
-                uses: actions/upload-artifact@v7
+                uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
                 with:
                     name: docs
                     path: |
@@ -51,7 +51,7 @@ jobs:
                     retention-days: 7
 
             -   name: Upload search indexes
-                uses: actions/upload-artifact@v7
+                uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
                 with:
                     name: ${{ env.ARTIFACT_INDEXES }}
                     path: artifacts/${{ env.ALGOLIA_ARTIFACT }}
@@ -60,23 +60,26 @@ jobs:
     test:
         needs: build
         name: Testing
+        permissions:
+            contents: read
         runs-on: ubuntu-latest
 
         steps:
             -   name: Download docs artifact
-                uses: actions/download-artifact@v8
+                uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
                 with:
                     name: docs
                     path: artifacts
 
             -   name: Test documentation
-                uses: JetBrains/writerside-checker-action@v1
+                uses: JetBrains/writerside-checker-action@79ff89902dcd3d5c5a3f26a79bc35830377f38c5
                 with:
                     instance: ${{ env.INSTANCE }}
 
     robots:
         needs: build
         name: Generate robots.txt
+        permissions: {}
         runs-on: ubuntu-latest
 
         steps:
@@ -89,7 +92,7 @@ jobs:
                     echo "Sitemap: https://${{ env.DOMAIN_NAME }}/sitemap.xml" >> robots.txt
 
             -   name: Upload artifacts
-                uses: actions/upload-artifact@v7
+                uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
                 with:
                     name: robots
                     path: robots.txt
@@ -105,16 +108,19 @@ jobs:
             - robots
 
         name: Deploy to pages
+        permissions:
+            id-token: write
+            pages: write
         runs-on: ubuntu-latest
 
         steps:
             -   name: Download docs artifact
-                uses: actions/download-artifact@v8
+                uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
                 with:
                     name: docs
 
             -   name: Download robots artifact
-                uses: actions/download-artifact@v8
+                uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
                 with:
                     name: robots
 
@@ -126,16 +132,16 @@ jobs:
                     sudo mv robots.txt dir/robots.txt
 
             -   name: Setup Pages
-                uses: actions/configure-pages@v6
+                uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d
 
             -   name: Upload artifact
-                uses: actions/upload-pages-artifact@v5
+                uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9
                 with:
                     path: dir
 
             -   name: Deploy to GitHub Pages
                 id: deployment
-                uses: actions/deploy-pages@v5
+                uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128
 
     deploy-indexes:
         environment: deploy
@@ -144,6 +150,7 @@ jobs:
             - test
         
         name: Deploy to Algolia
+        permissions: {}
         runs-on: ubuntu-latest
         timeout-minutes: 3
 
@@ -152,7 +159,7 @@ jobs:
 
         steps:
             -   name: Download search artifact
-                uses: actions/download-artifact@v8
+                uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
                 with:
                     name: ${{ env.ARTIFACT_INDEXES }}
 

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -5,6 +5,12 @@ on:
     - cron: '0 3 1 1 *'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   Update:
-    uses: TheDragonCode/.github/.github/workflows/license.yml@main
+    permissions:
+      contents: write
+      pull-requests: write
+
+    uses: TheDragonCode/.github/.github/workflows/license.yml@114cea00473063594c1ac778a22344341c177a70

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -5,10 +5,12 @@ on:
         -   cron: '20 2 * * *'
     workflow_dispatch:
 
-permissions:
-    contents: write
-    pull-requests: write
+permissions: {}
 
 jobs:
     preview:
-        uses: TheDragonCode/.github/.github/workflows/preview.yml@main
+        permissions:
+            contents: write
+            pull-requests: write
+
+        uses: TheDragonCode/.github/.github/workflows/preview.yml@114cea00473063594c1ac778a22344341c177a70

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,6 +6,12 @@ on:
             - main
     workflow_dispatch:
 
+permissions: {}
+
 jobs:
     Update:
-        uses: TheDragonCode/.github/.github/workflows/release-drafter.yml@main
+        permissions:
+            contents: write
+            pull-requests: write
+
+        uses: TheDragonCode/.github/.github/workflows/release-drafter.yml@114cea00473063594c1ac778a22344341c177a70

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -5,7 +5,8 @@ on:
         branches-ignore:
             - main
 
-permissions: read-all
+permissions:
+    contents: read
 
 env:
     COMPOSER_TOKEN: ${{ secrets.COMPOSER_TOKEN }}
@@ -19,12 +20,12 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            -   uses: actions/checkout@v7
+            -   uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
                 with:
                     fetch-depth: 0
 
             -   name: Build documentation
-                uses: JetBrains/writerside-github-action@v4
+                uses: JetBrains/writerside-github-action@738910d7cf197d67188300d0e0f84b2e708db3cf
                 with:
                     instance: ${{ env.INSTANCE }}
                     artifact: ${{ env.ARTIFACT_DOCS }}
@@ -32,6 +33,6 @@ jobs:
 
 
             -   name: Test documentation
-                uses: JetBrains/writerside-checker-action@v1
+                uses: JetBrains/writerside-checker-action@79ff89902dcd3d5c5a3f26a79bc35830377f38c5
                 with:
                     instance: ${{ env.INSTANCE }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,11 @@
 name: Tests
 
 on:
+    pull_request:
     push:
+
+permissions:
+    contents: read
 
 jobs:
     validate:
@@ -11,10 +15,10 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v7
+                uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
             -   name: Setup PHP
-                uses: shivammathur/setup-php@v2
+                uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240
                 with:
                     php-version: 8.5
                     coverage: none
@@ -38,10 +42,10 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v7
+                uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
             -   name: Setup PHP
-                uses: shivammathur/setup-php@v2
+                uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240
                 with:
                     php-version: ${{ matrix.php }}
                     extensions: curl, mbstring, zip, pcntl, pdo, pdo_sqlite, iconv
@@ -60,10 +64,10 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v7
+                uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
             -   name: Setup PHP
-                uses: shivammathur/setup-php@v2
+                uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240
                 with:
                     php-version: 8.2
                     extensions: curl, mbstring, zip, pcntl, pdo, pdo_sqlite, iconv
@@ -82,10 +86,10 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v7
+                uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
             -   name: Setup PHP
-                uses: shivammathur/setup-php@v2
+                uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240
                 with:
                     php-version: 8.5
                     extensions: curl, mbstring, zip, pcntl, pdo, pdo_sqlite, iconv
@@ -104,10 +108,10 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v7
+                uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
             -   name: Setup PHP
-                uses: shivammathur/setup-php@v2
+                uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240
                 with:
                     php-version: 8.5
                     extensions: curl, mbstring, zip, pcntl, pdo, pdo_sqlite, iconv


### PR DESCRIPTION
### What:

- [x] Bug Fix
- [ ] New Feature

### Description:

GitHub Actions workflows used mutable action tags and reusable workflow branches. Several workflows also granted broader `GITHUB_TOKEN` permissions than their jobs required.

This pull request:

- pins every external action and reusable workflow reference to a reviewed full commit SHA;
- replaces broad workflow permissions with explicit job-level permissions;
- limits Pages and OIDC write access to the Pages deployment job;
- grants read-only contents access to test and documentation validation jobs;
- runs the required test workflow for pull requests;
- keeps the existing Dependabot configuration for automated GitHub Actions updates.

The change reduces the impact of a compromised or unexpectedly changed workflow dependency without changing application behavior.

### Validation:

- parsed all GitHub YAML files successfully;
- verified all 30 external `uses` references use full 40-character commit SHAs;
- verified no workflow uses `write-all` or `read-all`;
- passed `git diff --check`;
- passed `composer validate --strict --no-check-lock`.

### Related:

Closes #170