### PR TITLE
Support remote storage disks

### DIFF
--- a/docs/snippets/advanced-feed-storage.php
+++ b/docs/snippets/advanced-feed-storage.php
@@ -6,7 +6,7 @@ use DragonCode\LaravelFeed\Feeds\Feed;
 
 class UserFeed extends Feed
 {
-    protected string $storage = 'public';
+    protected string $storage = 's3';
 
     public function filename(): string
     {

--- a/docs/topics/location.topic
+++ b/docs/topics/location.topic
@@ -33,4 +33,54 @@
     </p>
 
     <code-block lang="php" src="advanced-feed-storage.php" include-lines="5-" />
+
+    <chapter title="Supported disks" id="supported_disks">
+        <p>
+            Feed generation supports Laravel disks that resolve to
+            <code>Illuminate\Filesystem\FilesystemAdapter</code>. This includes the <code>local</code>,
+            <code>s3</code>, <code>sftp</code>, and <code>ftp</code> drivers when their Flysystem adapters are installed and
+            configured. Custom adapters are supported when they provide writable streams, file moves, directory
+            management and listings, and deletion through Flysystem.
+        </p>
+
+        <warning>
+            Read-only disks and custom disks that implement only
+            <code>Illuminate\Contracts\Filesystem\Filesystem</code> are not supported. An incompatible disk fails before
+            the feed database query starts with an <code>UnsupportedStorageDiskException</code>.
+        </warning>
+    </chapter>
+
+    <chapter title="Path contract" id="path_contract">
+        <list>
+            <li><code>storage()</code> returns the configured <code>FilesystemAdapter</code>.</li>
+            <li>
+                <code>storagePath()</code> returns the disk-relative path used for storage operations, including an
+                optional split-file suffix.
+            </li>
+            <li>
+                <code>path()</code> returns the path resolved by Laravel's adapter. It is an absolute filesystem path for
+                a local disk and an adapter-resolved path for a remote disk.
+            </li>
+        </list>
+    </chapter>
+
+    <chapter title="Publication guarantees" id="publication_guarantees">
+        <p>
+            Every feed part is completed before publication starts. Local disks publish staged files with filesystem
+            moves under an exclusive application lock. If a move fails, Laravel Feeds attempts to restore every
+            previous file from its staging backup.
+        </p>
+
+        <p>
+            Remote disks receive complete staged files through Flysystem streams before published objects are changed.
+            Publication then moves each staged object into place and attempts the same rollback on failure.
+        </p>
+
+        <warning>
+            Remote moves can be implemented as copy-and-delete operations and may be eventually consistent. Atomic
+            replacement of one object or an entire split feed is therefore not guaranteed. The publication lock is
+            local to the application host, so generators running on different hosts require an external distributed
+            lock if they can publish the same feed concurrently.
+        </warning>
+    </chapter>
 </topic>

--- a/src/Exceptions/UnsupportedStorageDiskException.php
+++ b/src/Exceptions/UnsupportedStorageDiskException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DragonCode\LaravelFeed\Exceptions;
+
+use Illuminate\Filesystem\FilesystemAdapter;
+use RuntimeException;
+
+use function sprintf;
+
+class UnsupportedStorageDiskException extends RuntimeException
+{
+    public function __construct(string $disk, string $storage)
+    {
+        parent::__construct(sprintf(
+            'Feed storage disk [%s] must resolve to [%s], [%s] returned.',
+            $disk,
+            FilesystemAdapter::class,
+            $storage
+        ));
+    }
+}

--- a/src/Feeds/Feed.php
+++ b/src/Feeds/Feed.php
@@ -6,11 +6,12 @@ namespace DragonCode\LaravelFeed\Feeds;
 
 use DragonCode\LaravelFeed\Data\ElementData;
 use DragonCode\LaravelFeed\Enums\FeedFormatEnum;
+use DragonCode\LaravelFeed\Exceptions\UnsupportedStorageDiskException;
 use DragonCode\LaravelFeed\Feeds\Info\FeedInfo;
 use DragonCode\LaravelFeed\Feeds\Items\FeedItem;
-use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -18,6 +19,7 @@ use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
 
 use function class_basename;
+use function get_debug_type;
 
 abstract class Feed
 {
@@ -99,10 +101,15 @@ abstract class Feed
 
     public function path(int|string $suffix = ''): string
     {
+        return $this->storage()->path(
+            $this->storagePath($suffix)
+        );
+    }
+
+    public function storagePath(int|string $suffix = ''): string
+    {
         if (empty($suffix)) {
-            return $this->storage()->path(
-                $this->filename()
-            );
+            return $this->filename();
         }
 
         $filename = $this->filename();
@@ -115,14 +122,20 @@ abstract class Feed
             $suffix = '-' . $suffix;
         }
 
-        return $this->storage()->path(
-            "$directory/$basename$suffix.$extension"
-        );
+        $filename = "$basename$suffix.$extension";
+
+        return $directory === '.' ? $filename : "$directory/$filename";
     }
 
-    public function storage(): Filesystem
+    public function storage(): FilesystemAdapter
     {
-        return Storage::disk($this->storage);
+        $storage = Storage::disk($this->storage);
+
+        if (! $storage instanceof FilesystemAdapter) {
+            throw new UnsupportedStorageDiskException($this->storage, get_debug_type($storage));
+        }
+
+        return $storage;
     }
 
     public function format(): FeedFormatEnum

--- a/src/Services/FilesystemService.php
+++ b/src/Services/FilesystemService.php
@@ -10,7 +10,10 @@ use DragonCode\LaravelFeed\Exceptions\OpenFeedException;
 use DragonCode\LaravelFeed\Exceptions\ResourceMetaException;
 use DragonCode\LaravelFeed\Exceptions\WriteFeedException;
 use Illuminate\Filesystem\Filesystem as File;
+use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Filesystem\LockableFile;
+use League\Flysystem\FilesystemOperator;
+use League\Flysystem\Local\LocalFilesystemAdapter;
 use RuntimeException;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
 use Throwable;
@@ -154,6 +157,35 @@ class FilesystemService
         }
     }
 
+    public function publishTo(FilesystemAdapter $storage, string $path, Closure $callback): void
+    {
+        if ($storage->getAdapter() instanceof LocalFilesystemAdapter) {
+            $this->publish($storage->path($path), function (string $staging) use ($callback, $storage) {
+                $drafts = $callback($staging);
+
+                if (! is_array($drafts)) {
+                    return $drafts;
+                }
+
+                $resolved = [];
+
+                foreach ($drafts as $target => $draft) {
+                    if (! is_string($target)) {
+                        throw new RuntimeException('Staged feed paths and publication targets must be strings.');
+                    }
+
+                    $resolved[$storage->path($target)] = $draft;
+                }
+
+                return $resolved;
+            });
+
+            return;
+        }
+
+        $this->publishRemote($storage, $path, $callback);
+    }
+
     public function publish(string $path, Closure $callback): void
     {
         $this->lock($path, function () use ($callback, $path) {
@@ -184,6 +216,55 @@ class FilesystemService
                 }
 
                 throw $cleanupFailure;
+            }
+
+            if ($failure !== null) {
+                throw $failure;
+            }
+        });
+    }
+
+    protected function publishRemote(FilesystemAdapter $storage, string $path, Closure $callback): void
+    {
+        $filesystem = $storage->getDriver();
+        $lock       = get_class($storage->getAdapter()) . ':' . $storage->path($path);
+
+        $this->lock($lock, function () use ($callback, $filesystem, $path) {
+            $localStaging = $this->createTemporaryDirectory(
+                sys_get_temp_dir(),
+                fn () => 'laravel_feeds_' . $this->uniqueIdentifier()
+            );
+            $remoteStaging = $this->storageStagingPath($path);
+            $cleanupRemote = false;
+            $failure       = null;
+
+            try {
+                $drafts = $callback($localStaging->path());
+
+                $this->commitStorage($filesystem, $path, $drafts, $remoteStaging, $cleanupRemote);
+            } catch (Throwable $e) {
+                $failure = $e;
+            }
+
+            if (! $localStaging->delete()) {
+                $failure = $this->withCleanupFailure(
+                    $failure,
+                    new RuntimeException("Unable to clean the local feed staging directory: [{$localStaging->path()}].")
+                );
+            }
+
+            if ($cleanupRemote) {
+                try {
+                    $filesystem->deleteDirectory($remoteStaging);
+                } catch (Throwable $e) {
+                    $failure = $this->withCleanupFailure(
+                        $failure,
+                        new RuntimeException(
+                            "Unable to clean the remote feed staging directory: [$remoteStaging].",
+                            previous: $e
+                        )
+                    );
+                }
             }
 
             if ($failure !== null) {
@@ -228,6 +309,67 @@ class FilesystemService
         }
 
         return $backup;
+    }
+
+    protected function commitStorage(
+        FilesystemOperator $storage,
+        string $path,
+        mixed $drafts,
+        string $staging,
+        bool &$cleanup,
+    ): void {
+        $drafts = $this->validateStorageDrafts($path, $drafts);
+
+        $cleanup   = true;
+        $backups   = [];
+        $installed = [];
+
+        try {
+            $drafts   = $this->stageStorageDrafts($storage, $drafts, $staging);
+            $existing = $this->publishedStoragePaths($storage, $path);
+            $targets  = array_keys($drafts);
+
+            foreach ($drafts as $target => $draft) {
+                if ($storage->fileExists($target)) {
+                    $backup           = $this->storageBackupPath($storage, $staging);
+                    $backups[$target] = $backup;
+
+                    $storage->move($target, $backup);
+                }
+
+                $installed[] = $target;
+
+                $storage->move($draft, $target);
+            }
+
+            foreach ($existing as $published) {
+                if ($this->containsStoragePath($targets, $published) || ! $storage->fileExists($published)) {
+                    continue;
+                }
+
+                $backup              = $this->storageBackupPath($storage, $staging);
+                $backups[$published] = $backup;
+
+                $storage->move($published, $backup);
+            }
+        } catch (Throwable $e) {
+            $rollbackFailure = $this->rollbackStorage($storage, $installed, $backups);
+
+            if ($rollbackFailure !== null) {
+                $cleanup = false;
+
+                throw new CloseFeedException(
+                    $path,
+                    new RuntimeException(
+                        $e->getMessage() . ' Rollback failed: ' . $rollbackFailure->getMessage()
+                        . " Backups were preserved at: [$staging].",
+                        previous: $e
+                    )
+                );
+            }
+
+            throw new CloseFeedException($path, $e);
+        }
     }
 
     protected function commit(string $path, array $drafts, string $staging, bool &$cleanup): void
@@ -287,6 +429,19 @@ class FilesystemService
 
         foreach ($paths as $path) {
             if ($this->pathKey($path) === $key) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    protected function containsStoragePath(array $paths, string $expected): bool
+    {
+        $key = $this->storagePathKey($expected);
+
+        foreach ($paths as $path) {
+            if ($this->storagePathKey($path) === $key) {
                 return true;
             }
         }
@@ -392,6 +547,31 @@ class FilesystemService
         return DIRECTORY_SEPARATOR === '\\' ? strtolower($path) : $path;
     }
 
+    protected function publishedStoragePaths(FilesystemOperator $storage, string $path): array
+    {
+        $paths = [];
+
+        if ($storage->fileExists($path)) {
+            $paths[] = $path;
+        }
+
+        foreach ($storage->listContents($this->storageDirectory($path), false) as $file) {
+            if (! $file->isFile()) {
+                continue;
+            }
+
+            $candidate = $file->path();
+
+            if ($this->matchesSplitFilename(basename($candidate), basename($path))) {
+                $paths[] = $candidate;
+            }
+        }
+
+        sort($paths, SORT_NATURAL);
+
+        return $paths;
+    }
+
     protected function publishedPaths(string $path): array
     {
         $paths = [];
@@ -452,6 +632,110 @@ class FilesystemService
         return new RuntimeException(implode('; ', $messages), previous: $failures[0]);
     }
 
+    protected function rollbackStorage(FilesystemOperator $storage, array $installed, array $backups): ?Throwable
+    {
+        $failures = [];
+
+        foreach (array_reverse($installed) as $path) {
+            try {
+                if ($storage->fileExists($path)) {
+                    $storage->delete($path);
+                }
+            } catch (Throwable $e) {
+                $failures[] = $e;
+            }
+        }
+
+        foreach (array_reverse($backups, true) as $path => $backup) {
+            try {
+                $targetExists = $storage->fileExists($path);
+
+                if (! $storage->fileExists($backup)) {
+                    if (! $targetExists) {
+                        throw new RuntimeException("Feed backup is missing during rollback: [$backup].");
+                    }
+
+                    continue;
+                }
+
+                if ($targetExists) {
+                    $storage->delete($path);
+                }
+
+                $storage->move($backup, $path);
+            } catch (Throwable $e) {
+                $failures[] = $e;
+            }
+        }
+
+        if ($failures === []) {
+            return null;
+        }
+
+        $messages = [];
+
+        foreach ($failures as $failure) {
+            $messages[] = get_class($failure) . ': ' . $failure->getMessage();
+        }
+
+        return new RuntimeException(implode('; ', $messages), previous: $failures[0]);
+    }
+
+    protected function stageStorageDrafts(FilesystemOperator $storage, array $drafts, string $staging): array
+    {
+        $staged = [];
+
+        foreach ($drafts as $target => $draft) {
+            $path     = $staging . '/drafts/' . $this->uniqueIdentifier();
+            $resource = @fopen($draft, 'rb');
+
+            if ($resource === false) {
+                throw new RuntimeException("Unable to open the staged feed for reading: [$draft].");
+            }
+
+            try {
+                $storage->writeStream($path, $resource);
+            } finally {
+                fclose($resource);
+            }
+
+            $staged[$target] = $path;
+        }
+
+        return $staged;
+    }
+
+    protected function storageBackupPath(FilesystemOperator $storage, string $staging): string
+    {
+        $directory = $staging . '/backups';
+
+        if (! $storage->directoryExists($directory)) {
+            $storage->createDirectory($directory);
+        }
+
+        return $directory . '/' . $this->uniqueIdentifier();
+    }
+
+    protected function storageDirectory(string $path): string
+    {
+        $directory = pathinfo($path, PATHINFO_DIRNAME);
+
+        return $directory === '.' ? '' : $directory;
+    }
+
+    protected function storagePathKey(string $path): string
+    {
+        return str_replace('\\', '/', $path);
+    }
+
+    protected function storageStagingPath(string $path): string
+    {
+        $directory = $this->storageDirectory($path);
+        $staging   = '.feeds_staging_' . $this->uniqueIdentifier();
+
+        return $directory === '' ? $staging : "$directory/$staging";
+    }
+
     protected function temporaryFilename(string $filename): string
     {
         return 'feeds_draft_' . $this->uniqueIdentifier();
@@ -464,6 +748,34 @@ class FilesystemService
 
     protected function validateDrafts(string $path, array $drafts): array
     {
+        return $this->validateDraftMap(
+            $path,
+            $drafts,
+            fn (string $target, string $publication) => $this->isPublicationPath($target, $publication),
+            fn (string $target)                      => $this->pathKey($target),
+        );
+    }
+
+    protected function validateStorageDrafts(string $path, mixed $drafts): array
+    {
+        if (! is_array($drafts)) {
+            throw new RuntimeException('The publication callback must return an array of staged files.');
+        }
+
+        return $this->validateDraftMap(
+            $path,
+            $drafts,
+            fn (string $target, string $publication) => $this->isStoragePublicationPath($target, $publication),
+            fn (string $target)                      => $this->storagePathKey($target),
+        );
+    }
+
+    protected function validateDraftMap(
+        string $path,
+        array $drafts,
+        Closure $isPublicationPath,
+        Closure $targetPathKey,
+    ): array {
         if ($drafts === []) {
             throw new RuntimeException("No staged feeds were provided for publication: [$path].");
         }
@@ -477,7 +789,7 @@ class FilesystemService
                 throw new RuntimeException('Staged feed paths and publication targets must be strings.');
             }
 
-            if (! $this->isPublicationPath($target, $path)) {
+            if (! $isPublicationPath($target, $path)) {
                 throw new RuntimeException("Invalid feed publication target: [$target].");
             }
 
@@ -485,7 +797,7 @@ class FilesystemService
                 throw new RuntimeException("Staged feed does not exist: [$draft].");
             }
 
-            $targetKey = $this->pathKey($target);
+            $targetKey = $targetPathKey($target);
             $sourceKey = $this->pathKey($draft);
 
             if (isset($targets[$targetKey])) {
@@ -502,6 +814,31 @@ class FilesystemService
         }
 
         return $validated;
+    }
+
+    protected function isStoragePublicationPath(string $path, string $publication): bool
+    {
+        if ($this->storagePathKey($path) === $this->storagePathKey($publication)) {
+            return true;
+        }
+
+        if ($this->storagePathKey(dirname($path)) !== $this->storagePathKey(dirname($publication))) {
+            return false;
+        }
+
+        return $this->matchesSplitFilename(basename($path), basename($publication));
+    }
+
+    protected function withCleanupFailure(?Throwable $failure, Throwable $cleanupFailure): Throwable
+    {
+        if ($failure === null) {
+            return $cleanupFailure;
+        }
+
+        return new RuntimeException(
+            $failure->getMessage() . ' ' . $cleanupFailure->getMessage(),
+            previous: $failure
+        );
     }
 
     /** @param  resource  $file */

--- a/src/Services/GeneratorService.php
+++ b/src/Services/GeneratorService.php
@@ -35,8 +35,9 @@ class GeneratorService
 
     public function feed(Feed $feed, ?OutputStyle $output = null): GenerationResultData
     {
-        $class = get_class($feed);
-        $path  = $feed->path();
+        $class   = get_class($feed);
+        $storage = $feed->storage();
+        $path    = $feed->path();
 
         $this->debug($output, 'Generation started.', [
             'feed' => $class,
@@ -49,24 +50,28 @@ class GeneratorService
             $converter = $this->converter($feed);
             $result    = null;
 
-            $this->filesystem->publish($path, function (string $staging) use ($feed, $output, $converter, &$result) {
-                $this->debug($output, 'Publication lock acquired and staging created.', [
-                    'feed'    => get_class($feed),
-                    'staging' => $staging,
-                ]);
+            $this->filesystem->publishTo(
+                $storage,
+                $feed->storagePath(),
+                function (string $staging) use ($feed, $output, $converter, &$result) {
+                    $this->debug($output, 'Publication lock acquired and staging created.', [
+                        'feed'    => get_class($feed),
+                        'staging' => $staging,
+                    ]);
 
-                $drafts = [];
-                $result = $this->export($feed, $output, $this->filesystem, $staging, $drafts, $converter);
+                    $drafts = [];
+                    $result = $this->export($feed, $output, $this->filesystem, $staging, $drafts, $converter);
 
-                $this->debug($output, 'All feed parts staged.', [
-                    'feed'    => get_class($feed),
-                    'parts'   => count($result->paths),
-                    'paths'   => $result->paths,
-                    'records' => $result->records,
-                ]);
+                    $this->debug($output, 'All feed parts staged.', [
+                        'feed'    => get_class($feed),
+                        'parts'   => count($result->paths),
+                        'paths'   => $result->paths,
+                        'records' => $result->records,
+                    ]);
 
-                return $drafts;
-            });
+                    return $drafts;
+                }
+            );
 
             if (! $result instanceof GenerationResultData) {
                 throw new RuntimeException('Feed generation did not produce a result.');
@@ -124,7 +129,7 @@ class GeneratorService
             ->export();
 
         return new GenerationResultData(
-            paths  : array_keys($drafts),
+            paths  : array_keys($records),
             records: $records,
         );
     }
@@ -154,10 +159,11 @@ class GeneratorService
         return function ($file, int $index, int $count) use ($feed, &$drafts, &$records, $converter) {
             $this->performFooter($file, $feed, $converter);
 
-            $path = $feed->path($index);
+            $storagePath = $feed->storagePath($index);
+            $path        = $feed->path($index);
 
-            $drafts[$path]  = $this->filesystem->finishDraft($file);
-            $records[$path] = $count;
+            $drafts[$storagePath] = $this->filesystem->finishDraft($file);
+            $records[$path]       = $count;
         };
     }
 

--- a/tests/.pest/snapshots/Feature/Feeds/StorageTest/keeps_local_disk_generation_and_absolute_paths_supported.snap
+++ b/tests/.pest/snapshots/Feature/Feeds/StorageTest/keeps_local_disk_generation_and_absolute_paths_supported.snap
@@ -1,0 +1,1 @@
+end of snapshots

--- a/tests/.pest/snapshots/Feature/Feeds/StorageTest/preserves_remote_staging_when_rollback_fails.snap
+++ b/tests/.pest/snapshots/Feature/Feeds/StorageTest/preserves_remote_staging_when_rollback_fails.snap
@@ -1,0 +1,1 @@
+end of snapshots

--- a/tests/.pest/snapshots/Feature/Feeds/StorageTest/publishes_a_feed_to_a_remote_Flysystem_adapter_through_streams.snap
+++ b/tests/.pest/snapshots/Feature/Feeds/StorageTest/publishes_a_feed_to_a_remote_Flysystem_adapter_through_streams.snap
@@ -1,0 +1,1 @@
+end of snapshots

--- a/tests/.pest/snapshots/Feature/Feeds/StorageTest/rejects_unsupported_storage_contracts_before_building_the_database_query.snap
+++ b/tests/.pest/snapshots/Feature/Feeds/StorageTest/rejects_unsupported_storage_contracts_before_building_the_database_query.snap
@@ -1,0 +1,1 @@
+end of snapshots

--- a/tests/.pest/snapshots/Feature/Feeds/StorageTest/replaces_remote_feeds_and_removes_obsolete_split_parts.snap
+++ b/tests/.pest/snapshots/Feature/Feeds/StorageTest/replaces_remote_feeds_and_removes_obsolete_split_parts.snap
@@ -1,0 +1,1 @@
+end of snapshots

--- a/tests/.pest/snapshots/Feature/Feeds/StorageTest/reports_publication_and_remote_staging_cleanup_failures_together.snap
+++ b/tests/.pest/snapshots/Feature/Feeds/StorageTest/reports_publication_and_remote_staging_cleanup_failures_together.snap
@@ -1,0 +1,1 @@
+end of snapshots

--- a/tests/.pest/snapshots/Feature/Feeds/StorageTest/reports_remote_staging_cleanup_failures_after_a_successful_publication.snap
+++ b/tests/.pest/snapshots/Feature/Feeds/StorageTest/reports_remote_staging_cleanup_failures_after_a_successful_publication.snap
@@ -1,0 +1,1 @@
+end of snapshots

--- a/tests/.pest/snapshots/Feature/Feeds/StorageTest/restores_remote_feed_parts_when_publication_fails.snap
+++ b/tests/.pest/snapshots/Feature/Feeds/StorageTest/restores_remote_feed_parts_when_publication_fails.snap
@@ -1,0 +1,1 @@
+end of snapshots

--- a/tests/.pest/snapshots/Feature/Feeds/StorageTest/validates_remote_publication_drafts.snap
+++ b/tests/.pest/snapshots/Feature/Feeds/StorageTest/validates_remote_publication_drafts.snap
@@ -1,0 +1,1 @@
+end of snapshots

--- a/tests/Feature/Feeds/StorageTest.php
+++ b/tests/Feature/Feeds/StorageTest.php
@@ -1,0 +1,455 @@
+<?php
+
+declare(strict_types=1);
+
+use DragonCode\LaravelFeed\Enums\FeedFormatEnum;
+use DragonCode\LaravelFeed\Events\FeedFinishedEvent;
+use DragonCode\LaravelFeed\Events\FeedStartingEvent;
+use DragonCode\LaravelFeed\Exceptions\FeedGenerationException;
+use DragonCode\LaravelFeed\Exceptions\UnsupportedStorageDiskException;
+use DragonCode\LaravelFeed\Feeds\Feed;
+use DragonCode\LaravelFeed\Feeds\Info\FeedInfo;
+use DragonCode\LaravelFeed\Services\FilesystemService;
+use DragonCode\LaravelFeed\Services\GeneratorService;
+use Illuminate\Contracts\Filesystem\Filesystem as FilesystemContract;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Storage;
+use League\Flysystem\Config;
+use League\Flysystem\DecoratedAdapter;
+use League\Flysystem\Filesystem as Flysystem;
+use League\Flysystem\Local\LocalFilesystemAdapter;
+use League\Flysystem\UnableToDeleteDirectory;
+use League\Flysystem\UnableToDeleteFile;
+use League\Flysystem\UnableToMoveFile;
+use Spatie\TemporaryDirectory\TemporaryDirectory;
+use Workbench\App\Data\NewsFakeData;
+use Workbench\App\Models\News;
+
+final class RemoteFeedFilesystemAdapter extends DecoratedAdapter
+{
+    public int $streamWrites = 0;
+
+    protected ?string $failedDestination = null;
+
+    protected ?string $failedDelete = null;
+
+    protected bool $failedDirectoryDelete = false;
+
+    public function failNextDelete(string $path): void
+    {
+        $this->failedDelete = $path;
+    }
+
+    public function failNextDirectoryDelete(): void
+    {
+        $this->failedDirectoryDelete = true;
+    }
+
+    public function failNextMoveTo(string $destination): void
+    {
+        $this->failedDestination = $destination;
+    }
+
+    public function writeStream(string $path, $contents, Config $config): void
+    {
+        $this->streamWrites++;
+
+        parent::writeStream($path, $contents, $config);
+    }
+
+    public function delete(string $path): void
+    {
+        if ($this->failedDelete === $path) {
+            $this->failedDelete = null;
+
+            throw UnableToDeleteFile::atLocation($path, 'Injected remote delete failure.');
+        }
+
+        parent::delete($path);
+    }
+
+    public function deleteDirectory(string $path): void
+    {
+        if ($this->failedDirectoryDelete) {
+            $this->failedDirectoryDelete = false;
+
+            throw UnableToDeleteDirectory::atLocation($path, 'Injected remote directory delete failure.');
+        }
+
+        parent::deleteDirectory($path);
+    }
+
+    public function move(string $source, string $destination, Config $config): void
+    {
+        if ($this->failedDestination === $destination) {
+            $this->failedDestination = null;
+
+            throw UnableToMoveFile::because('Injected remote move failure.', $source, $destination);
+        }
+
+        parent::move($source, $destination, $config);
+    }
+}
+
+final class RemoteFeedStorage
+{
+    public static RemoteFeedFilesystemAdapter $adapter;
+
+    public static TemporaryDirectory $directory;
+
+    public static function create(): void
+    {
+        self::$directory = (new TemporaryDirectory)->create();
+        self::$adapter   = new RemoteFeedFilesystemAdapter(
+            new LocalFilesystemAdapter(self::$directory->path())
+        );
+
+        Storage::set('remote-feeds', new FilesystemAdapter(
+            new Flysystem(self::$adapter),
+            self::$adapter,
+            ['root' => 'remote-root']
+        ));
+    }
+
+    public static function delete(): void
+    {
+        Storage::forgetDisk('remote-feeds');
+
+        self::$directory->delete();
+    }
+}
+
+final class LocalStorageFeed extends Feed
+{
+    protected FeedFormatEnum $format = FeedFormatEnum::JsonLines;
+
+    protected string $storage = 'local-feeds';
+
+    public function builder(): Builder
+    {
+        return News::query();
+    }
+
+    public function filename(): string
+    {
+        return 'exports/local-feed.jsonl';
+    }
+
+    public function info(): FeedInfo
+    {
+        return new FeedInfo;
+    }
+}
+
+final class RemoteStorageFeed extends Feed
+{
+    public static int $perFile = 0;
+
+    protected FeedFormatEnum $format = FeedFormatEnum::JsonLines;
+
+    protected string $storage = 'remote-feeds';
+
+    public function builder(): Builder
+    {
+        return News::query();
+    }
+
+    public function filename(): string
+    {
+        return 'exports/remote-feed.jsonl';
+    }
+
+    public function info(): FeedInfo
+    {
+        return new FeedInfo;
+    }
+
+    public function perFile(): int
+    {
+        return self::$perFile;
+    }
+}
+
+final class UnsupportedStorageFeed extends Feed
+{
+    public static int $builderCalls = 0;
+
+    protected string $storage = 'unsupported-feeds';
+
+    public function builder(): Builder
+    {
+        self::$builderCalls++;
+
+        return News::query();
+    }
+}
+
+function remoteStagingFiles(FilesystemAdapter $storage): array
+{
+    return array_values(array_filter(
+        $storage->allFiles(),
+        static fn (string $path) => str_contains($path, '.feeds_staging_')
+    ));
+}
+
+function remoteFeedDraft(string $staging, string $name): string
+{
+    $path = $staging . DIRECTORY_SEPARATOR . $name;
+
+    file_put_contents($path, $name);
+
+    return $path;
+}
+
+beforeEach(function () {
+    RemoteStorageFeed::$perFile           = 0;
+    UnsupportedStorageFeed::$builderCalls = 0;
+
+    Storage::fake('local-feeds');
+    RemoteFeedStorage::create();
+});
+
+afterEach(function () {
+    Storage::forgetDisk('local-feeds');
+    Storage::forgetDisk('unsupported-feeds');
+
+    RemoteFeedStorage::delete();
+});
+
+test('keeps local disk generation and absolute paths supported', function () {
+    createNews(...NewsFakeData::toArray());
+
+    $feed   = app(LocalStorageFeed::class);
+    $result = app(GeneratorService::class)->feed($feed);
+
+    expect($feed->storagePath())
+        ->toBe('exports/local-feed.jsonl')
+        ->and($feed->path())
+        ->toBeFile()
+        ->and($feed->storage()->exists($feed->storagePath()))
+        ->toBeTrue()
+        ->and($result->paths)
+        ->toBe([$feed->path()]);
+});
+
+test('publishes a feed to a remote Flysystem adapter through streams', function () {
+    createNews(...NewsFakeData::toArray());
+
+    $feed    = app(RemoteStorageFeed::class);
+    $storage = $feed->storage();
+    $result  = app(GeneratorService::class)->feed($feed);
+
+    expect($feed->storagePath())
+        ->toBe('exports/remote-feed.jsonl')
+        ->and($feed->path())
+        ->toBe($storage->path($feed->storagePath()))
+        ->and($storage->exists($feed->storagePath()))
+        ->toBeTrue()
+        ->and($storage->get($feed->storagePath()))
+        ->toContain('Some content 1')
+        ->and(RemoteFeedStorage::$adapter->streamWrites)
+        ->toBe(1)
+        ->and(remoteStagingFiles($storage))
+        ->toBe([])
+        ->and($result->paths)
+        ->toBe([$feed->path()]);
+});
+
+test('restores remote feed parts when publication fails', function () {
+    RemoteStorageFeed::$perFile = 1;
+
+    createNews(...NewsFakeData::toArray());
+
+    $feed      = app(RemoteStorageFeed::class);
+    $storage   = $feed->storage();
+    $generator = app(GeneratorService::class);
+    $result    = $generator->feed($feed);
+    $published = [];
+
+    foreach (array_keys($result->paths) as $offset) {
+        $path             = $feed->storagePath($offset + 1);
+        $published[$path] = 'old-' . ($offset + 1);
+
+        $storage->put($path, $published[$path]);
+    }
+
+    Event::fake();
+
+    RemoteFeedStorage::$adapter->failNextMoveTo($feed->storagePath(2));
+
+    expect(fn () => $generator->feed($feed))
+        ->toThrow(FeedGenerationException::class, 'Injected remote move failure.');
+
+    foreach ($published as $path => $content) {
+        expect($storage->get($path))->toBe($content);
+    }
+
+    expect(remoteStagingFiles($storage))->toBe([]);
+
+    Event::assertNotDispatched(FeedFinishedEvent::class);
+});
+
+test('replaces remote feeds and removes obsolete split parts', function () {
+    RemoteStorageFeed::$perFile = 1;
+
+    createNews(...NewsFakeData::toArray());
+
+    $feed      = app(RemoteStorageFeed::class);
+    $storage   = $feed->storage();
+    $generator = app(GeneratorService::class);
+
+    $generator->feed($feed);
+
+    RemoteStorageFeed::$perFile = 0;
+
+    $generator->feed($feed);
+
+    expect($storage->exists($feed->storagePath()))
+        ->toBeTrue()
+        ->and($storage->exists($feed->storagePath(1)))
+        ->toBeFalse()
+        ->and($storage->exists($feed->storagePath(2)))
+        ->toBeFalse()
+        ->and($storage->exists($feed->storagePath(3)))
+        ->toBeFalse();
+
+    $storage->put($feed->storagePath(), 'old-single');
+
+    $generator->feed($feed);
+
+    expect($storage->get($feed->storagePath()))
+        ->not->toBe('old-single')
+        ->and(remoteStagingFiles($storage))
+        ->toBe([]);
+});
+
+test('validates remote publication drafts', function () {
+    $storage     = app(RemoteStorageFeed::class)->storage();
+    $filesystem  = app(FilesystemService::class);
+    $publication = 'exports/validation.jsonl';
+    $split       = 'exports/validation-1.jsonl';
+
+    $cases = [
+        'array of staged files' => [
+            static fn (string $staging) => null,
+            'The publication callback must return an array of staged files.',
+        ],
+        'non-empty staged files' => [
+            static fn (string $staging) => [],
+            'No staged feeds were provided for publication',
+        ],
+        'string paths' => [
+            static fn (string $staging) => [remoteFeedDraft($staging, 'numeric-target')],
+            'Staged feed paths and publication targets must be strings.',
+        ],
+        'publication target' => [
+            static fn (string $staging) => [
+                'other/validation.jsonl' => remoteFeedDraft($staging, 'invalid-target'),
+            ],
+            'Invalid feed publication target',
+        ],
+        'existing draft' => [
+            static fn (string $staging) => [$publication => $staging . DIRECTORY_SEPARATOR . 'missing'],
+            'Staged feed does not exist',
+        ],
+        'unique target' => [
+            static fn (string $staging) => [
+                $publication                         => remoteFeedDraft($staging, 'first-target'),
+                str_replace('/', '\\', $publication) => remoteFeedDraft($staging, 'second-target'),
+            ],
+            'Duplicate feed publication target',
+        ],
+        'unique draft' => [
+            static function (string $staging) use ($publication, $split) {
+                $draft = remoteFeedDraft($staging, 'duplicate-draft');
+
+                return [
+                    $publication => $draft,
+                    $split       => $draft,
+                ];
+            },
+            'Duplicate staged feed',
+        ],
+    ];
+
+    foreach ($cases as [$drafts, $message]) {
+        expect(fn () => $filesystem->publishTo($storage, $publication, $drafts))
+            ->toThrow(RuntimeException::class, $message);
+    }
+});
+
+test('reports remote staging cleanup failures after a successful publication', function () {
+    createNews(...NewsFakeData::toArray());
+
+    $feed = app(RemoteStorageFeed::class);
+
+    RemoteFeedStorage::$adapter->failNextDirectoryDelete();
+
+    expect(fn () => app(GeneratorService::class)->feed($feed))
+        ->toThrow(FeedGenerationException::class, 'Unable to clean the remote feed staging directory');
+
+    expect($feed->storage()->exists($feed->storagePath()))->toBeTrue();
+});
+
+test('reports publication and remote staging cleanup failures together', function () {
+    createNews(...NewsFakeData::toArray());
+
+    $feed = app(RemoteStorageFeed::class);
+
+    RemoteFeedStorage::$adapter->failNextMoveTo($feed->storagePath());
+    RemoteFeedStorage::$adapter->failNextDirectoryDelete();
+
+    expect(fn () => app(GeneratorService::class)->feed($feed))
+        ->toThrow(FeedGenerationException::class, 'Unable to clean the remote feed staging directory')
+        ->and($feed->storage()->exists($feed->storagePath()))
+        ->toBeFalse();
+});
+
+test('preserves remote staging when rollback fails', function () {
+    RemoteStorageFeed::$perFile = 1;
+
+    createNews(...NewsFakeData::toArray());
+
+    $feed      = app(RemoteStorageFeed::class);
+    $storage   = $feed->storage();
+    $generator = app(GeneratorService::class);
+    $result    = $generator->feed($feed);
+    $published = [];
+
+    foreach (array_keys($result->paths) as $offset) {
+        $path             = $feed->storagePath($offset + 1);
+        $published[$path] = 'old-' . ($offset + 1);
+
+        $storage->put($path, $published[$path]);
+    }
+
+    RemoteFeedStorage::$adapter->failNextMoveTo($feed->storagePath(2));
+    RemoteFeedStorage::$adapter->failNextDelete($feed->storagePath(1));
+
+    expect(fn () => $generator->feed($feed))
+        ->toThrow(FeedGenerationException::class, 'Rollback failed:');
+
+    foreach ($published as $path => $content) {
+        expect($storage->get($path))->toBe($content);
+    }
+
+    expect(remoteStagingFiles($storage))->not->toBe([]);
+});
+
+test('rejects unsupported storage contracts before building the database query', function () {
+    Event::fake();
+
+    Storage::set('unsupported-feeds', mock(FilesystemContract::class));
+
+    expect(fn () => app(GeneratorService::class)->feed(app(UnsupportedStorageFeed::class)))
+        ->toThrow(
+            UnsupportedStorageDiskException::class,
+            'Feed storage disk [unsupported-feeds] must resolve to [Illuminate\\Filesystem\\FilesystemAdapter]'
+        )
+        ->and(UnsupportedStorageFeed::$builderCalls)
+        ->toBe(0);
+
+    Event::assertNotDispatched(FeedStartingEvent::class);
+});


### PR DESCRIPTION
## Summary

- publish non-local feed drafts through Flysystem streams
- preserve local filesystem publication and rollback behavior
- expose disk-relative storage paths and document consistency guarantees

## Why

Feed generation resolved every disk to a native filesystem path, so configured S3, SFTP, FTP, and custom remote disks could not be published safely.

## Impact

Remote Laravel disks backed by `FilesystemAdapter` are now supported. Local disk paths remain unchanged. Remote publication uses staged objects and rollback, but atomic visibility depends on adapter semantics and publication locks remain local to each application host.

## Validation

- 276 tests, 1383 assertions
- 95.9% code coverage
- 99.6% type coverage
- Pint
- Writerside XML validation
- `git diff --check`

Closes #171