### PR TITLE
Preserve query ordering and limits during feed export

### DIFF
--- a/.ai-factory/RULES.md
+++ b/.ai-factory/RULES.md
@@ -5,4 +5,5 @@
 ## Rules
 
 - Never use `Illuminate\Support\Facades\Log` or add logging through Laravel facades.
+- Never add diagnostic logging through console output.
 - When creating a pull request, assign exactly one label only when the change clearly matches one category: `added` for new functionality, `fix` for a functionality or other defect fix, `minor` for non-critical project structure changes, or `removed` for removed functionality or content; otherwise assign no label.

--- a/.ai-factory/patches/2026-07-22-01.29-preserve-query-semantics.md
+++ b/.ai-factory/patches/2026-07-22-01.29-preserve-query-semantics.md
@@ -1,0 +1,28 @@
+# Feed export discarded query ordering and bounds
+
+**Date:** 2026-07-22
+**Severity:** High
+**Files:** `src/Services/ExportService.php`, `tests/Feature/Feeds/QuerySemanticsTest.php`
+
+## Problem
+
+Feed exports changed explicitly configured query ordering and ignored `limit` and `offset` clauses when the result crossed a chunk boundary. Progress-enabled exports could also calculate an incorrect total for bounded queries.
+
+## Root Cause
+
+The export service always iterated with `lazyById()`. That method replaces the query order with primary-key pagination and removes the original limit and offset while building each chunk. Counting the original builder directly also applied its offset and limit to the aggregate instead of counting the bounded result set.
+
+## Solution
+
+Unbounded queries now use Laravel's ordered lazy chunk iterator. Queries with a limit or offset use bounded offset pagination that retains the original query clauses and chunk size. Progress totals for bounded queries are calculated from a subquery. Real Eloquent regression tests cover custom ordering, limits, offsets, progress totals, and unbounded chunking.
+
+## Prevention
+
+- Exercise query semantics with a real database-backed Eloquent builder.
+- Cover result sets larger than the configured chunk size.
+- Verify ordering, limits, offsets, and progress totals independently.
+- Keep unbounded exports lazy and bounded exports constrained by their original query.
+
+## Tags
+
+`feeds`, `eloquent`, `pagination`, `streaming`, `regression`, `issue-190`

--- a/.ai-factory/patches/2026-07-22-01.29-preserve-query-semantics.md
+++ b/.ai-factory/patches/2026-07-22-01.29-preserve-query-semantics.md
@@ -14,7 +14,7 @@ The export service always iterated with `lazyById()`. That method replaces the q
 
 ## Solution
 
-Unbounded queries now use Laravel's ordered lazy chunk iterator. Queries with a limit or offset use bounded offset pagination that retains the original query clauses and chunk size. Progress totals for bounded queries are calculated from a subquery. Real Eloquent regression tests cover custom ordering, limits, offsets, progress totals, and unbounded chunking.
+Unbounded queries with explicit ordering use Laravel's ordered lazy chunk iterator, while unordered exports retain keyset pagination. Queries with a limit or offset use bounded offset pagination that retains the original query clauses and chunk size. Progress totals for bounded queries are calculated from a subquery with a synthetic limit for offset-only builders. Real Eloquent regression tests cover custom ordering, limits, offsets, progress totals, and unbounded chunking.
 
 ## Prevention
 

--- a/docs/snippets/receipt-rss-feed.xml
+++ b/docs/snippets/receipt-rss-feed.xml
@@ -20,15 +20,6 @@
   <pubDate>Thu, 04 Sep 2025 02:44:27 +0000</pubDate>
   <foo>bar</foo>
 </item>
-<item>
-  <title>Some 3</title>
-  <link>https://example.com/news/some-3</link>
-  <guid>3</guid>
-  <description><![CDATA[Some content 3]]></description>
-  <category>Some category 3</category>
-  <pubDate>Thu, 04 Sep 2025 01:06:18 +0000</pubDate>
-  <foo>bar</foo>
-</item>
 
 </channel>
 </rss>

--- a/src/Services/ExportService.php
+++ b/src/Services/ExportService.php
@@ -13,12 +13,9 @@ use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\LazyCollection;
 use InvalidArgumentException;
 use Symfony\Component\Console\Helper\ProgressBar;
-use Throwable;
 
-use function get_class;
 use function intdiv;
 use function is_resource;
-use function json_encode;
 use function min;
 use function value;
 
@@ -48,8 +45,6 @@ class ExportService
     protected $resource;
 
     protected int $records = 0;
-
-    protected int $exportedRecords = 0;
 
     protected int $writtenFiles = 0;
 
@@ -129,19 +124,7 @@ class ExportService
 
             $this->store(true);
 
-            $this->debug('Export query iteration finished.', [
-                'records' => $this->exportedRecords,
-            ]);
-
             $this->progressBar?->finish();
-        } catch (Throwable $e) {
-            $this->debug('Export query iteration failed.', [
-                'records'   => $this->exportedRecords,
-                'exception' => get_class($e),
-                'message'   => $e->getMessage(),
-            ]);
-
-            throw $e;
         } finally {
             if (is_resource($this->resource)) {
                 $this->filesystem->close($this->resource);
@@ -168,7 +151,6 @@ class ExportService
     protected function write(Model $model, bool $hasNext): void
     {
         $this->records++;
-        $this->exportedRecords++;
 
         $fileCompleted = $this->perFile > 0 && $this->records >= $this->perFile;
 
@@ -273,16 +255,14 @@ class ExportService
     {
         $builder = $this->feed->builder()->applyScopes()->withoutGlobalScopes();
         $query   = $builder->getQuery();
-        $bounded = $this->isBounded($query);
 
-        $this->debug('Export query iteration configured.', [
-            'mode'       => $bounded ? 'bounded_chunks' : 'chunks',
-            'chunk_size' => $this->chunk,
-        ]);
+        if ($this->isBounded($query)) {
+            return $this->boundedModels($builder, $query);
+        }
 
-        return $bounded
-            ? $this->boundedModels($builder, $query)
-            : $builder->lazy($this->chunk);
+        return $this->isOrdered($query)
+            ? $builder->lazy($this->chunk)
+            : $builder->lazyById($this->chunk);
     }
 
     protected function boundedModels(Builder $builder, QueryBuilder $query): LazyCollection
@@ -290,7 +270,7 @@ class ExportService
         $offset    = $this->queryOffset($query);
         $remaining = $this->queryLimit($query);
 
-        if (empty($query->orders) && empty($query->unionOrders)) {
+        if (! $this->isOrdered($query)) {
             $key = empty($query->unions)
                 ? $builder->getModel()->getQualifiedKeyName()
                 : $builder->getModel()->getKeyName();
@@ -334,14 +314,25 @@ class ExportService
         $builder = $this->feed->builder();
         $query   = $builder->toBase();
 
-        return $this->modelCount = $this->isBounded($query)
-            ? $query->newQuery()->fromSub($query, 'feed_models')->count()
-            : $builder->count();
+        if (! $this->isBounded($query)) {
+            return $this->modelCount = $builder->count();
+        }
+
+        if ($this->queryLimit($query) === null) {
+            $query->limit(PHP_INT_MAX);
+        }
+
+        return $this->modelCount = $query->newQuery()->fromSub($query, 'feed_models')->count();
     }
 
     protected function isBounded(QueryBuilder $query): bool
     {
         return $this->queryLimit($query) !== null || $this->queryOffset($query) > 0;
+    }
+
+    protected function isOrdered(QueryBuilder $query): bool
+    {
+        return ! empty($query->orders) || ! empty($query->unionOrders);
     }
 
     protected function queryLimit(QueryBuilder $query): ?int
@@ -352,15 +343,6 @@ class ExportService
     protected function queryOffset(QueryBuilder $query): int
     {
         return (int) (empty($query->unions) ? $query->offset : $query->unionOffset);
-    }
-
-    protected function debug(string $message, array $context): void
-    {
-        if (! $this->output?->isDebug()) {
-            return;
-        }
-
-        $this->output->writeln('[laravel-feeds] [FIX:190] ' . $message . ' ' . json_encode($context));
     }
 
     protected function createProgressBar(int $total): ?ProgressBar

--- a/src/Services/ExportService.php
+++ b/src/Services/ExportService.php
@@ -7,12 +7,18 @@ namespace DragonCode\LaravelFeed\Services;
 use Closure;
 use DragonCode\LaravelFeed\Feeds\Feed;
 use Illuminate\Console\OutputStyle;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\LazyCollection;
 use InvalidArgumentException;
 use Symfony\Component\Console\Helper\ProgressBar;
+use Throwable;
 
+use function get_class;
 use function intdiv;
 use function is_resource;
+use function json_encode;
 use function min;
 use function value;
 
@@ -103,7 +109,7 @@ class ExportService
     {
         try {
             $pending = null;
-            $models  = $this->feed->builder()->lazyById($this->chunk);
+            $models  = $this->models();
 
             if (($limit = $this->total ?? $this->capacity) !== null) {
                 $models = $models->take($limit);
@@ -123,7 +129,19 @@ class ExportService
 
             $this->store(true);
 
+            $this->debug('Export query iteration finished.', [
+                'records' => $this->exportedRecords,
+            ]);
+
             $this->progressBar?->finish();
+        } catch (Throwable $e) {
+            $this->debug('Export query iteration failed.', [
+                'records'   => $this->exportedRecords,
+                'exception' => get_class($e),
+                'message'   => $e->getMessage(),
+            ]);
+
+            throw $e;
         } finally {
             if (is_resource($this->resource)) {
                 $this->filesystem->close($this->resource);
@@ -251,9 +269,98 @@ class ExportService
         return $this->perFile * $this->maxFiles;
     }
 
+    protected function models(): LazyCollection
+    {
+        $builder = $this->feed->builder()->applyScopes()->withoutGlobalScopes();
+        $query   = $builder->getQuery();
+        $bounded = $this->isBounded($query);
+
+        $this->debug('Export query iteration configured.', [
+            'mode'       => $bounded ? 'bounded_chunks' : 'chunks',
+            'chunk_size' => $this->chunk,
+        ]);
+
+        return $bounded
+            ? $this->boundedModels($builder, $query)
+            : $builder->lazy($this->chunk);
+    }
+
+    protected function boundedModels(Builder $builder, QueryBuilder $query): LazyCollection
+    {
+        $offset    = $this->queryOffset($query);
+        $remaining = $this->queryLimit($query);
+
+        if (empty($query->orders) && empty($query->unionOrders)) {
+            $key = empty($query->unions)
+                ? $builder->getModel()->getQualifiedKeyName()
+                : $builder->getModel()->getKeyName();
+
+            $builder->orderBy($key);
+        }
+
+        return LazyCollection::make(function () use ($builder, $offset, $remaining) {
+            while ($remaining === null || $remaining > 0) {
+                $limit  = $remaining === null ? $this->chunk : min($this->chunk, $remaining);
+                $models = (clone $builder)->offset($offset)->limit($limit)->get();
+                $count  = $models->count();
+
+                if ($count === 0) {
+                    return;
+                }
+
+                foreach ($models as $model) {
+                    yield $model;
+                }
+
+                if ($count < $limit) {
+                    return;
+                }
+
+                $offset += $count;
+
+                if ($remaining !== null) {
+                    $remaining -= $count;
+                }
+            }
+        });
+    }
+
     protected function modelCount(): int
     {
-        return $this->modelCount ??= $this->feed->builder()->count();
+        if ($this->modelCount !== null) {
+            return $this->modelCount;
+        }
+
+        $builder = $this->feed->builder();
+        $query   = $builder->toBase();
+
+        return $this->modelCount = $this->isBounded($query)
+            ? $query->newQuery()->fromSub($query, 'feed_models')->count()
+            : $builder->count();
+    }
+
+    protected function isBounded(QueryBuilder $query): bool
+    {
+        return $this->queryLimit($query) !== null || $this->queryOffset($query) > 0;
+    }
+
+    protected function queryLimit(QueryBuilder $query): ?int
+    {
+        return empty($query->unions) ? $query->limit : $query->unionLimit;
+    }
+
+    protected function queryOffset(QueryBuilder $query): int
+    {
+        return (int) (empty($query->unions) ? $query->offset : $query->unionOffset);
+    }
+
+    protected function debug(string $message, array $context): void
+    {
+        if (! $this->output?->isDebug()) {
+            return;
+        }
+
+        $this->output->writeln('[laravel-feeds] [FIX:190] ' . $message . ' ' . json_encode($context));
     }
 
     protected function createProgressBar(int $total): ?ProgressBar

--- a/tests/.pest/snapshots/Feature/Feeds/QuerySemanticsTest/counts_bounded_queries_exactly_for_progress_reporting.snap
+++ b/tests/.pest/snapshots/Feature/Feeds/QuerySemanticsTest/counts_bounded_queries_exactly_for_progress_reporting.snap
@@ -1,0 +1,1 @@
+end of snapshots

--- a/tests/.pest/snapshots/Feature/Feeds/QuerySemanticsTest/keeps_unbounded_queries_streamed_in_configured_chunks.snap
+++ b/tests/.pest/snapshots/Feature/Feeds/QuerySemanticsTest/keeps_unbounded_queries_streamed_in_configured_chunks.snap
@@ -1,0 +1,1 @@
+end of snapshots

--- a/tests/.pest/snapshots/Feature/Feeds/QuerySemanticsTest/preserves_non_primary_key_ordering_across_chunks.snap
+++ b/tests/.pest/snapshots/Feature/Feeds/QuerySemanticsTest/preserves_non_primary_key_ordering_across_chunks.snap
@@ -1,0 +1,1 @@
+end of snapshots

--- a/tests/.pest/snapshots/Feature/Feeds/QuerySemanticsTest/respects_a_query_limit.snap
+++ b/tests/.pest/snapshots/Feature/Feeds/QuerySemanticsTest/respects_a_query_limit.snap
@@ -1,0 +1,1 @@
+end of snapshots

--- a/tests/.pest/snapshots/Feature/Feeds/QuerySemanticsTest/respects_a_query_offset.snap
+++ b/tests/.pest/snapshots/Feature/Feeds/QuerySemanticsTest/respects_a_query_offset.snap
@@ -1,0 +1,1 @@
+end of snapshots

--- a/tests/Feature/Feeds/QuerySemanticsTest.php
+++ b/tests/Feature/Feeds/QuerySemanticsTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+use DragonCode\LaravelFeed\Enums\FeedFormatEnum;
+use DragonCode\LaravelFeed\Feeds\Feed;
+use DragonCode\LaravelFeed\Services\GeneratorService;
+use Illuminate\Console\OutputStyle;
+use Illuminate\Database\Eloquent\Builder;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Workbench\App\Models\News;
+
+final class QuerySemanticsFeed extends Feed
+{
+    public static Builder $query;
+
+    protected FeedFormatEnum $format = FeedFormatEnum::JsonLines;
+
+    public function builder(): Builder
+    {
+        return clone self::$query;
+    }
+
+    public function chunkSize(): int
+    {
+        return 2;
+    }
+
+    public function filename(): string
+    {
+        return 'query-semantics.jsonl';
+    }
+}
+
+function querySemanticsIds(Builder $query, ?OutputStyle $output = null): array
+{
+    QuerySemanticsFeed::$query = $query;
+
+    $feed = app(QuerySemanticsFeed::class);
+
+    app(GeneratorService::class)->feed($feed, $output);
+
+    return array_column(
+        parseJsonLines(readFeedFile($feed->path())),
+        'id'
+    );
+}
+
+beforeEach(function () {
+    createNews(
+        ['title' => 'Delta', 'content' => 'one', 'category' => 'news'],
+        ['title' => 'Alpha', 'content' => 'two', 'category' => 'news'],
+        ['title' => 'Charlie', 'content' => 'three', 'category' => 'news'],
+        ['title' => 'Bravo', 'content' => 'four', 'category' => 'news'],
+    );
+});
+
+test('preserves non-primary-key ordering across chunks', function () {
+    expect(querySemanticsIds(News::query()->orderBy('title')))
+        ->toBe([2, 4, 3, 1]);
+});
+
+test('respects a query limit', function () {
+    expect(querySemanticsIds(News::query()->orderBy('id')->limit(2)))
+        ->toBe([1, 2]);
+});
+
+test('respects a query offset', function () {
+    expect(querySemanticsIds(News::query()->orderBy('id')->offset(1)->limit(3)))
+        ->toBe([2, 3, 4]);
+});
+
+test('counts bounded queries exactly for progress reporting', function () {
+    $buffer = new BufferedOutput(OutputInterface::VERBOSITY_DEBUG);
+    $output = new OutputStyle(new ArrayInput([]), $buffer);
+
+    expect(querySemanticsIds(News::query()->orderBy('id')->offset(1)->limit(2), $output))
+        ->toBe([2, 3])
+        ->and($buffer->fetch())
+        ->toContain('[laravel-feeds] [FIX:190] Export query iteration configured.');
+});
+
+test('keeps unbounded queries streamed in configured chunks', function () {
+    $batches = [];
+
+    $query = News::query()
+        ->orderBy('id')
+        ->afterQuery(function ($models) use (&$batches) {
+            $batches[] = $models->count();
+        });
+
+    expect(querySemanticsIds($query))
+        ->toBe([1, 2, 3, 4])
+        ->and($batches)
+        ->not->toBeEmpty()
+        ->and(max($batches))
+        ->toBeLessThan(4);
+});

--- a/tests/Feature/Feeds/QuerySemanticsTest.php
+++ b/tests/Feature/Feeds/QuerySemanticsTest.php
@@ -76,10 +76,11 @@ test('counts bounded queries exactly for progress reporting', function () {
     $buffer = new BufferedOutput(OutputInterface::VERBOSITY_DEBUG);
     $output = new OutputStyle(new ArrayInput([]), $buffer);
 
-    expect(querySemanticsIds(News::query()->orderBy('id')->offset(1)->limit(2), $output))
-        ->toBe([2, 3])
+    expect(querySemanticsIds(News::query()->orderBy('id')->offset(1), $output))
+        ->toBe([2, 3, 4])
         ->and($buffer->fetch())
-        ->toContain('[laravel-feeds] [FIX:190] Export query iteration configured.');
+        ->toContain('3/3')
+        ->not->toContain('[FIX:190]');
 });
 
 test('keeps unbounded queries streamed in configured chunks', function () {

--- a/tests/Helpers/Benchmark/builders.php
+++ b/tests/Helpers/Benchmark/builders.php
@@ -3,15 +3,29 @@
 declare(strict_types=1);
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\LazyCollection;
 
 function mockRegressionFeedBuilder(array $models): Builder
 {
     $builder = Mockery::mock(Builder::class);
+    $query   = Mockery::mock(QueryBuilder::class);
 
     $builder->shouldNotReceive('count');
     $builder
-        ->shouldReceive('lazyById')
+        ->shouldReceive('applyScopes')
+        ->once()
+        ->andReturnSelf();
+    $builder
+        ->shouldReceive('withoutGlobalScopes')
+        ->once()
+        ->andReturnSelf();
+    $builder
+        ->shouldReceive('getQuery')
+        ->once()
+        ->andReturn($query);
+    $builder
+        ->shouldReceive('lazy')
         ->once()
         ->with(1000)
         ->andReturn(LazyCollection::make($models));

--- a/tests/Helpers/Benchmark/builders.php
+++ b/tests/Helpers/Benchmark/builders.php
@@ -25,7 +25,7 @@ function mockRegressionFeedBuilder(array $models): Builder
         ->once()
         ->andReturn($query);
     $builder
-        ->shouldReceive('lazy')
+        ->shouldReceive('lazyById')
         ->once()
         ->with(1000)
         ->andReturn(LazyCollection::make($models));

--- a/tests/Unit/Services/ExportServiceTest.php
+++ b/tests/Unit/Services/ExportServiceTest.php
@@ -22,7 +22,7 @@ function mockUnboundedExportBuilder(LazyCollection $models, int $chunk): Builder
     $builder->shouldReceive('applyScopes')->once()->andReturnSelf();
     $builder->shouldReceive('withoutGlobalScopes')->once()->andReturnSelf();
     $builder->shouldReceive('getQuery')->once()->andReturn($query);
-    $builder->shouldReceive('lazy')->once()->with($chunk)->andReturn($models);
+    $builder->shouldReceive('lazyById')->once()->with($chunk)->andReturn($models);
 
     return $builder;
 }

--- a/tests/Unit/Services/ExportServiceTest.php
+++ b/tests/Unit/Services/ExportServiceTest.php
@@ -8,9 +8,24 @@ use DragonCode\LaravelFeed\Services\FilesystemService;
 use Illuminate\Console\OutputStyle;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Query\Builder as QueryBuilder;
 use Illuminate\Support\LazyCollection;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
+
+function mockUnboundedExportBuilder(LazyCollection $models, int $chunk): Builder
+{
+    $builder = mock(Builder::class);
+    $query   = mock(QueryBuilder::class);
+
+    $builder->shouldReceive('toBase')->atMost()->once()->andReturn($query);
+    $builder->shouldReceive('applyScopes')->once()->andReturnSelf();
+    $builder->shouldReceive('withoutGlobalScopes')->once()->andReturnSelf();
+    $builder->shouldReceive('getQuery')->once()->andReturn($query);
+    $builder->shouldReceive('lazy')->once()->with($chunk)->andReturn($models);
+
+    return $builder;
+}
 
 test('writes each serialized item immediately', function (string $lineEnding) {
     $models = LazyCollection::make(function () {
@@ -22,9 +37,8 @@ test('writes each serialized item immediately', function (string $lineEnding) {
         }
     });
 
-    $builder = mock(Builder::class);
+    $builder = mockUnboundedExportBuilder($models, 2);
     $builder->shouldNotReceive('count');
-    $builder->shouldReceive('lazyById')->once()->with(2)->andReturn($models);
 
     $feed = mock(Feed::class);
     $feed->shouldReceive('perFile')->once()->andReturn(0);
@@ -75,9 +89,8 @@ test('respects split capacity', function (
         }
     });
 
-    $builder = mock(Builder::class);
+    $builder = mockUnboundedExportBuilder($models, 2);
     $builder->shouldNotReceive('count');
-    $builder->shouldReceive('lazyById')->once()->with(2)->andReturn($models);
 
     $feed = mock(Feed::class);
     $feed->shouldReceive('perFile')->once()->andReturn(2);
@@ -175,9 +188,8 @@ test('rejects a non-positive chunk size', function (int $chunk) {
 test('closes the active resource when export fails', function () {
     $model = mock(Model::class);
 
-    $builder = mock(Builder::class);
+    $builder = mockUnboundedExportBuilder(LazyCollection::make([$model]), 1);
     $builder->shouldNotReceive('count');
-    $builder->shouldReceive('lazyById')->once()->with(1)->andReturn(LazyCollection::make([$model]));
 
     $feed = mock(Feed::class);
     $feed->shouldReceive('perFile')->once()->andReturn(0);
@@ -206,9 +218,8 @@ test('closes the active resource when export fails', function () {
 });
 
 test('creates an empty feed without counting models', function () {
-    $builder = mock(Builder::class);
+    $builder = mockUnboundedExportBuilder(LazyCollection::make([]), 10);
     $builder->shouldNotReceive('count');
-    $builder->shouldReceive('lazyById')->once()->with(10)->andReturn(LazyCollection::make([]));
 
     $feed = mock(Feed::class);
     $feed->shouldReceive('perFile')->once()->andReturn(0);
@@ -251,9 +262,8 @@ test('counts models once when progress reporting needs an exact total', function
         }
     });
 
-    $builder = mock(Builder::class);
+    $builder = mockUnboundedExportBuilder($models, 2);
     $builder->shouldReceive('count')->once()->andReturn(3);
-    $builder->shouldReceive('lazyById')->once()->with(2)->andReturn($models);
 
     $feed = mock(Feed::class);
     $feed->shouldReceive('perFile')->once()->andReturn(0);
@@ -286,9 +296,8 @@ test('stops progress exports at the counted total', function () {
         }
     });
 
-    $builder = mock(Builder::class);
+    $builder = mockUnboundedExportBuilder($models, 2);
     $builder->shouldReceive('count')->once()->andReturn(3);
-    $builder->shouldReceive('lazyById')->once()->with(2)->andReturn($models);
 
     $feed = mock(Feed::class);
     $feed->shouldReceive('perFile')->once()->andReturn(0);


### PR DESCRIPTION
## Summary

- preserve explicit Eloquent ordering across export chunks
- respect query `limit` and `offset` clauses
- keep unbounded exports lazy and chunked
- calculate bounded progress totals from the constrained result set
- add database-backed regression coverage and update the affected RSS fixture

## Root cause

`ExportService` always used `lazyById()`. That iterator replaces the configured ordering with primary-key pagination and rebuilds chunk queries without retaining the original limit and offset.

## Impact

Feeds now export the same ordered and bounded result set described by their Eloquent builder while retaining chunked processing for large unbounded feeds.

## Validation

- targeted regression and service tests: 19 passed, 154 assertions
- Feature and Unit suites: 236 passed, 1320 assertions
- code coverage: 95.8%
- type coverage: 100%
- Pint, PHP lint, and `git diff --check`: passed
- benchmark time thresholds also fail on clean `HEAD`, so benchmark snapshots were not changed

Closes #190