### PR TITLE
Fix JSON root key escaping

### DIFF
--- a/.ai-factory/patches/2026-07-22-15.43.md
+++ b/.ai-factory/patches/2026-07-22-15.43.md
@@ -1,0 +1,28 @@
+# JSON root names were written without serializer escaping
+
+**Date:** 2026-07-22 15:43
+**Files:** src/Converters/JsonConverter.php, tests/Feature/Feeds/Formats/Json/RootTest.php
+**Severity:** medium
+
+## Problem
+
+JSON feeds became invalid when the configured root name contained quotes, backslashes, or control characters. Unicode root names also bypassed the configured JSON encoding options.
+
+## Root Cause
+
+`JsonConverter::root()` interpolated the root name directly between quotes while items and info blocks used `json_encode()`. The root path therefore skipped JSON string escaping and serializer options. Encoding the name as a scalar without accounting for `JSON_NUMERIC_CHECK` would also turn numeric-looking string keys into invalid unquoted property names.
+
+## Solution
+
+The root name is now encoded with the converter's JSON options before the array prefix is written. `JSON_NUMERIC_CHECK` is excluded only for the object key so numeric-looking names remain quoted. Regression coverage generates complete compact and pretty documents, decodes them with `JSON_THROW_ON_ERROR`, and verifies special-character, Unicode, configured-option, and numeric-key behavior.
+
+## Prevention
+
+- Serialize dynamic JSON property names instead of interpolating them.
+- Decode complete generated documents when testing streaming JSON fragments.
+- Exercise configured encoder flags against structural values such as object keys.
+- Keep value-only flags from changing JSON property-name semantics.
+
+## Tags
+
+`#json` `#escaping` `#root-key` `#serialization` `#regression` `#issue-192`

--- a/src/Converters/JsonConverter.php
+++ b/src/Converters/JsonConverter.php
@@ -41,7 +41,10 @@ class JsonConverter extends Converter implements FileAwareInfoConverter
 
     public function root(Feed $feed): string
     {
-        return sprintf("\"%s\": [\n", $feed->root()->name);
+        return sprintf(
+            "%s: [\n",
+            json_encode($feed->root()->name, $this->jsonOptions() & ~JSON_NUMERIC_CHECK)
+        );
     }
 
     public function item(FeedItem $item, bool $isLast): string

--- a/tests/.pest/snapshots/Feature/Feeds/Formats/Json/RootTest/serializes_root_names_as_valid_JSON_object_keys.snap
+++ b/tests/.pest/snapshots/Feature/Feeds/Formats/Json/RootTest/serializes_root_names_as_valid_JSON_object_keys.snap
@@ -1,0 +1,1 @@
+end of snapshots

--- a/tests/Feature/Feeds/Formats/Json/RootTest.php
+++ b/tests/Feature/Feeds/Formats/Json/RootTest.php
@@ -2,9 +2,47 @@
 
 declare(strict_types=1);
 
+use DragonCode\LaravelFeed\Data\ElementData;
 use DragonCode\LaravelFeed\Enums\FeedFormatEnum;
+use DragonCode\LaravelFeed\Services\GeneratorService;
 use Workbench\App\Data\NewsFakeData;
 use Workbench\App\Feeds\JsonRootFeed;
+
+final class EscapedJsonRootFeed extends JsonRootFeed
+{
+    public const ROOT = "quote\" backslash\\ newline\nUnicode ключ";
+
+    public function root(): ElementData
+    {
+        return new ElementData(
+            name      : self::ROOT,
+            beforeInfo: false
+        );
+    }
+
+    public function filename(): string
+    {
+        return 'escaped-json-root.json';
+    }
+}
+
+final class NumericJsonRootFeed extends JsonRootFeed
+{
+    public const ROOT = '123';
+
+    public function root(): ElementData
+    {
+        return new ElementData(
+            name      : self::ROOT,
+            beforeInfo: false
+        );
+    }
+
+    public function filename(): string
+    {
+        return 'numeric-json-root.json';
+    }
+}
 
 test('export', function (bool $pretty) {
     setPrettyXml($pretty);
@@ -13,3 +51,52 @@ test('export', function (bool $pretty) {
 
     expectFeedSnapshot(JsonRootFeed::class, FeedFormatEnum::Json);
 })->with('boolean');
+
+test('serializes root names as valid JSON object keys', function () {
+    $cases = [
+        'escaped root' => [
+            EscapedJsonRootFeed::class,
+            EscapedJsonRootFeed::ROOT,
+            JSON_HEX_QUOT | JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+            ['\\u0022', 'ключ'],
+        ],
+        'numeric root with numeric check' => [
+            NumericJsonRootFeed::class,
+            NumericJsonRootFeed::ROOT,
+            JSON_NUMERIC_CHECK | JSON_THROW_ON_ERROR,
+            ['"123"'],
+        ],
+    ];
+
+    createNews(...NewsFakeData::toArray());
+
+    foreach ([false, true] as $pretty) {
+        setPrettyXml($pretty);
+
+        foreach ($cases as [$class, $root, $options, $encodedFragments]) {
+            config()?->set('feeds.converters.json.options', $options);
+
+            $feed = app($class);
+
+            app(GeneratorService::class)->feed($feed);
+
+            $content  = readFeedFile($feed->path());
+            $document = json_decode(
+                json       : $content,
+                associative: true,
+                flags      : JSON_THROW_ON_ERROR
+            );
+
+            expect($document)
+                ->toBeArray()
+                ->and(array_key_exists($root, $document))
+                ->toBeTrue()
+                ->and($document[$root])
+                ->toHaveCount(count(NewsFakeData::toArray()));
+
+            foreach ($encodedFragments as $fragment) {
+                expect($content)->toContain($fragment);
+            }
+        }
+    }
+});


### PR DESCRIPTION
## Summary

- serialize JSON root names with the configured JSON encoder options
- keep numeric-looking object keys quoted when `JSON_NUMERIC_CHECK` is enabled
- add full-document regression coverage for escaped keys in compact and pretty output

## Root cause

`JsonConverter::root()` interpolated the configured root name directly into a quoted JSON fragment. Quotes, backslashes, and control characters therefore bypassed JSON escaping, while configured encoder flags did not apply to the key.

## Validation

- `php vendor/bin/pest tests/Feature/Feeds/Formats/Json/RootTest.php --filter="serializes root names" --colors=always` — 1 passed, 19 assertions
- `php vendor/bin/pint --test --ansi src/Converters/JsonConverter.php tests/Feature/Feeds/Formats/Json/RootTest.php` — passed
- `php -l` for both modified PHP files — passed
- `git diff --check` — passed
- full Pest run exited successfully with 250 passed tests; 37 existing snapshot cases were reported incomplete by the current local runner

Closes #192