### PR TITLE
fix(instagram): align feed item nullability

### DIFF
--- a/.ai-factory/patches/2026-07-22-16.35.md
+++ b/.ai-factory/patches/2026-07-22-16.35.md
@@ -1,0 +1,28 @@
+# Instagram feed setters accepted unsupported null values
+
+**Date:** 2026-07-22 16:35
+**Files:** src/Presets/Items/InstagramFeedItem.php, tests/Unit/Presets/Items/InstagramFeedItemTest.php
+**Severity:** medium
+
+## Problem
+
+The `image()`, `condition()`, `availability()`, `price()`, and `status()` methods accepted null values but assigned them to non-nullable typed properties. Calls such as `status(null)` failed with an assignment `TypeError` instead of following the declared public API contract.
+
+## Root Cause
+
+The setter signatures and backing property types were introduced with different nullability. The Instagram preset had no focused unit coverage for its public setter types or serialization of absent optional values, so the mismatch remained undetected.
+
+## Solution
+
+Required setters now declare non-nullable arguments that match their backing properties. The optional status property is nullable, so `status(null)` is accepted and omitted by the existing blank-value filter. Regression tests cover the public type contract, optional null serialization, default required values, and failure when an uninitialized required field reaches serialization.
+
+## Prevention
+
+- Keep setter parameter nullability aligned with backing property nullability.
+- Distinguish required feed fields from optional fields before widening types.
+- Cover public type contracts and serialized absence for nullable preset values.
+- Preserve serialization-time guards for required uninitialized fields.
+
+## Tags
+
+`#instagram` `#nullability` `#typed-properties` `#serialization` `#regression` `#issue-193`

--- a/src/Presets/Items/InstagramFeedItem.php
+++ b/src/Presets/Items/InstagramFeedItem.php
@@ -34,7 +34,7 @@ class InstagramFeedItem extends FeedItem
 
     protected ?string $groupId = null;
 
-    protected string $status = 'active';
+    protected ?string $status = 'active';
 
     protected ?int $googleCategory = null;
 
@@ -75,7 +75,7 @@ class InstagramFeedItem extends FeedItem
         return $this;
     }
 
-    public function image(?string $url): static
+    public function image(string $url): static
     {
         $this->image = $url;
 
@@ -89,21 +89,21 @@ class InstagramFeedItem extends FeedItem
         return $this;
     }
 
-    public function condition(?string $condition): static
+    public function condition(string $condition): static
     {
         $this->condition = $condition;
 
         return $this;
     }
 
-    public function availability(?string $availability): static
+    public function availability(string $availability): static
     {
         $this->availability = $availability;
 
         return $this;
     }
 
-    public function price(?float $price, ?float $salePrice = null): static
+    public function price(float $price, ?float $salePrice = null): static
     {
         $this->price     = $price;
         $this->salePrice = $salePrice ?? $price;

--- a/tests/Unit/Presets/Items/InstagramFeedItemTest.php
+++ b/tests/Unit/Presets/Items/InstagramFeedItemTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+use DragonCode\LaravelFeed\Presets\Items\InstagramFeedItem;
+use Illuminate\Database\Eloquent\Model;
+
+function instagramFeedItem(): InstagramFeedItem
+{
+    $model = new class extends Model {};
+
+    $model->setAttribute($model->getKeyName(), 123);
+
+    return new InstagramFeedItem($model);
+}
+
+test('aligns required setter arguments with non-nullable properties', function (string $method, string $property) {
+    $parameterType = (new ReflectionMethod(InstagramFeedItem::class, $method))
+        ->getParameters()[0]
+        ->getType();
+    $propertyType = (new ReflectionProperty(InstagramFeedItem::class, $property))->getType();
+
+    expect($parameterType)
+        ->not->toBeNull()
+        ->and($parameterType?->allowsNull())
+        ->toBeFalse()
+        ->and($propertyType)
+        ->not->toBeNull()
+        ->and($propertyType?->allowsNull())
+        ->toBeFalse();
+})->with([
+    'image'        => ['image', 'image'],
+    'condition'    => ['condition', 'condition'],
+    'availability' => ['availability', 'availability'],
+    'price'        => ['price', 'price'],
+]);
+
+test('aligns the nullable status argument with its property', function () {
+    $parameterType = (new ReflectionMethod(InstagramFeedItem::class, 'status'))
+        ->getParameters()[0]
+        ->getType();
+    $propertyType = (new ReflectionProperty(InstagramFeedItem::class, 'status'))->getType();
+
+    expect($parameterType)
+        ->not->toBeNull()
+        ->and($parameterType?->allowsNull())
+        ->toBeTrue()
+        ->and($propertyType)
+        ->not->toBeNull()
+        ->and($propertyType?->allowsNull())
+        ->toBeTrue();
+});
+
+test('omits accepted nullable values from serialization', function () {
+    $item = instagramFeedItem()
+        ->title('Product')
+        ->description('Description')
+        ->url('https://example.test/products/123')
+        ->image('https://example.test/images/123.jpg')
+        ->images(null)
+        ->price(10.0, null)
+        ->group(null)
+        ->status(null)
+        ->googleCategory(null)
+        ->facebookCategory(null);
+
+    expect($item->toArray())->toBe([
+        'g:id'           => 123,
+        'g:title'        => ['@cdata' => 'Product'],
+        'g:description'  => ['@cdata' => 'Description'],
+        'g:link'         => 'https://example.test/products/123',
+        'g:image_link'   => 'https://example.test/images/123.jpg',
+        'g:condition'    => 'new',
+        'g:availability' => 'in stock',
+        'g:price'        => 10.0,
+        'g:sale_price'   => 10.0,
+    ]);
+});
+
+test('fails serialization when a required field is absent', function (string $missing) {
+    $item = instagramFeedItem();
+
+    if ($missing !== 'title') {
+        $item->title('Product');
+    }
+
+    if ($missing !== 'description') {
+        $item->description('Description');
+    }
+
+    if ($missing !== 'url') {
+        $item->url('https://example.test/products/123');
+    }
+
+    if ($missing !== 'image') {
+        $item->image('https://example.test/images/123.jpg');
+    }
+
+    if ($missing !== 'price') {
+        $item->price(10.0);
+    }
+
+    expect(fn () => $item->toArray())->toThrow(Error::class);
+})->with([
+    'title',
+    'description',
+    'url',
+    'image',
+    'price',
+]);


### PR DESCRIPTION
## Summary

- align required Instagram setter signatures with their non-nullable properties
- allow `status(null)` and omit the absent optional value during serialization
- add regression coverage for nullable inputs and required field guards

## Root cause

Several public setters accepted `null` and assigned it directly to non-nullable typed properties, causing assignment `TypeError` exceptions. The preset had no focused tests for setter/property nullability or absent optional values.

## Validation

- targeted Instagram tests: 11 passed, 26 assertions
- full test suite: 249 passed, 45 incomplete, 1423 assertions
- type coverage: 100%
- coverage gate: 294 passed, 1535 assertions, 95.8%
- Pint and `git diff --check`: passed

Closes #193