### PR TITLE
Escape Instagram preset channel metadata in XML

### DIFF
--- a/.ai-factory/patches/2026-07-22-17.20.md
+++ b/.ai-factory/patches/2026-07-22-17.20.md
@@ -1,0 +1,28 @@
+# Instagram channel metadata produced malformed XML
+
+**Date:** 2026-07-22 17:20
+**Files:** src/Presets/InstagramFeedPreset.php, tests/Feature/Feeds/Presets/InstagramTest.php, tests/.pest/snapshots/Feature/Feeds/Presets/InstagramTest
+**Severity:** medium
+
+## Problem
+
+Instagram feeds became malformed when `app.name` or `app.url` contained XML-sensitive characters. Values such as `Shop & Partners` caused `DOMDocument` to report `EntityRef: expecting ';'` while parsing the complete feed.
+
+## Root Cause
+
+`InstagramFeedPreset::header()` interpolated application metadata directly into a raw XML fragment. Unlike feed roots and items, preset headers bypass the DOM-backed converter serialization path, so the dynamic text was never escaped.
+
+## Solution
+
+The preset now serializes both metadata values with XML-specific `htmlspecialchars()` flags, explicit UTF-8 encoding, and `double_encode: true`. The header markup and whitespace remain unchanged. A feature regression generates the complete feed in compact and pretty modes, parses it with `DOMDocument`, and verifies that title and link values round-trip exactly, including literal entity-like text.
+
+## Prevention
+
+- Serialize every dynamic value according to the context of the raw markup that contains it.
+- Keep XML text escaping local to raw preset fragments instead of applying it to generic headers or DOM-managed values.
+- Parse complete generated documents and compare decoded values when testing escaping.
+- Include literal entity-like input to detect accidental value changes from disabled double encoding.
+
+## Tags
+
+`#instagram` `#xml` `#escaping` `#serialization` `#regression` `#issue-194`

--- a/src/Presets/InstagramFeedPreset.php
+++ b/src/Presets/InstagramFeedPreset.php
@@ -11,6 +11,7 @@ use DragonCode\LaravelFeed\Presets\Items\InstagramFeedItem;
 use Illuminate\Database\Eloquent\Model;
 
 use function config;
+use function htmlspecialchars;
 
 abstract class InstagramFeedPreset extends Feed
 {
@@ -26,8 +27,8 @@ abstract class InstagramFeedPreset extends Feed
 
     public function header(): string
     {
-        $name = config('app.name');
-        $url  = config('app.url');
+        $name = $this->escapeXmlText((string) config('app.name'));
+        $url  = $this->escapeXmlText((string) config('app.url'));
 
         return <<<XML
             <rss xmlns:g="http://base.google.com/ns/1.0" version="2.0">
@@ -41,5 +42,15 @@ abstract class InstagramFeedPreset extends Feed
     public function footer(): string
     {
         return "\n</channel>\n</rss>";
+    }
+
+    private function escapeXmlText(string $value): string
+    {
+        return htmlspecialchars(
+            string       : $value,
+            flags        : ENT_QUOTES | ENT_SUBSTITUTE | ENT_XML1,
+            encoding     : 'UTF-8',
+            double_encode: true
+        );
     }
 }

--- a/tests/.pest/snapshots/Feature/Feeds/Presets/InstagramTest/serializes_channel_metadata_as_XML_text.snap
+++ b/tests/.pest/snapshots/Feature/Feeds/Presets/InstagramTest/serializes_channel_metadata_as_XML_text.snap
@@ -1,0 +1,1 @@
+end of snapshots

--- a/tests/Feature/Feeds/Presets/InstagramTest.php
+++ b/tests/Feature/Feeds/Presets/InstagramTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use DragonCode\LaravelFeed\Presets\InstagramFeedPreset;
+use DragonCode\LaravelFeed\Services\GeneratorService;
+use Illuminate\Database\Eloquent\Builder;
+use Workbench\App\Models\Product;
+
+final class InstagramMetadataFeed extends InstagramFeedPreset
+{
+    public function builder(): Builder
+    {
+        return Product::query();
+    }
+
+    public function filename(): string
+    {
+        return 'instagram-metadata.xml';
+    }
+}
+
+test('serializes channel metadata as XML text', function () {
+    $name = 'Shop & Partners <"Main"> \'Europe\' &amp; Co';
+    $url  = 'https://example.com/catalog?query=<summer>&partner="A&B"&literal=&amp;';
+
+    config()?->set([
+        'app.name' => $name,
+        'app.url'  => $url,
+    ]);
+
+    $feed = app(InstagramMetadataFeed::class);
+
+    foreach ([false, true] as $pretty) {
+        setPrettyXml($pretty);
+
+        app(GeneratorService::class)->feed($feed);
+
+        $document = parseXmlDocument(readFeedFile($feed->path()));
+        $channel  = $document->getElementsByTagName('channel')->item(0);
+
+        expect($document->documentElement?->nodeName)
+            ->toBe('rss')
+            ->and($channel)
+            ->toBeInstanceOf(DOMElement::class)
+            ->and($channel->getElementsByTagName('title')->item(0)?->textContent)
+            ->toBe($name)
+            ->and($channel->getElementsByTagName('link')->item(0)?->textContent)
+            ->toBe($url);
+    }
+});


### PR DESCRIPTION
## Summary

- escape `app.name` and `app.url` before interpolating them into the Instagram channel header
- preserve literal entity-like values by keeping XML double encoding enabled
- add a full-feed DOM round-trip regression for compact and pretty XML output

## Root cause

`InstagramFeedPreset::header()` inserted application metadata directly into raw XML. Preset headers bypass the DOM-backed item and root serialization path, so XML-sensitive characters could make the completed feed malformed.

## Validation

- `vendor\bin\pest tests\Unit\Converters\XmlConverterTest.php tests\Feature\Feeds\Presets\InstagramTest.php --colors=never` — 8 tests, 48 assertions
- `composer test:type -- --colors=never` — 100%
- `git diff --check`

Local Pint and `Feature/Docs` validation are blocked by the installed Pint PHAR containing a non-portable path to another checkout. The issue-specific and XML converter regression suites pass.

Closes #194