### PR TITLE
Stop feed scaffolding when the parent generator fails

### DIFF
--- a/.ai-factory/patches/2026-07-22-18.04.md
+++ b/.ai-factory/patches/2026-07-22-18.04.md
@@ -1,0 +1,27 @@
+# Feed scaffolding continued after generator failure
+
+**Date:** 2026-07-22 18:04
+**Files:** src/Commands/FeedMakeCommand.php, tests/Unit/Console/Make/FailureTest.php
+**Severity:** medium
+
+## Problem
+
+`make:feed` continued creating item and info classes and publishing a deploy operation or migration when the primary feed generator rejected an existing or reserved class name. The command also returned a successful exit status.
+
+## Root Cause
+
+`FeedMakeCommand::handle()` ignored the boolean failure returned by `GeneratorCommand::handle()` and declared a `void` return type. Execution therefore continued into dependent scaffolding, and Laravel converted the eventual null result to exit status zero.
+
+## Solution
+
+The command now converts the parent generator failure into `Command::FAILURE`, returns immediately, and returns `Command::SUCCESS` only after the full scaffold completes. Regression tests cover duplicate and reserved names, both registration backends, dependent artifact absence, and exact exit statuses.
+
+## Prevention
+
+- Check parent command outcomes before running dependent generators or publishers.
+- Return explicit Symfony console exit codes from composite commands.
+- Cover both filesystem side effects and process status for generator failure paths.
+
+## Tags
+
+`#console` `#generator` `#exit-code` `#side-effects` `#regression` `#issue-195`

--- a/src/Commands/FeedMakeCommand.php
+++ b/src/Commands/FeedMakeCommand.php
@@ -23,9 +23,11 @@ class FeedMakeCommand extends GeneratorCommand
 
     protected $type = 'Feed';
 
-    public function handle(): void
+    public function handle(): int
     {
-        parent::handle();
+        if (parent::handle() === false) {
+            return self::FAILURE;
+        }
 
         if ($this->option('item')) {
             $this->makeFeedItem(
@@ -45,6 +47,8 @@ class FeedMakeCommand extends GeneratorCommand
             $this->argument('name'),
             $this->getQualifyClass()
         );
+
+        return self::SUCCESS;
     }
 
     protected function makeOperation(string $name, string $class): void

--- a/tests/Unit/Console/Make/FailureTest.php
+++ b/tests/Unit/Console/Make/FailureTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+use DragonCode\LaravelFeed\Commands\FeedMakeCommand;
+use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Console\Command\Command;
+
+use function Pest\Laravel\artisan;
+
+test('stops scaffolding when the feed already exists', function () {
+    $filesystem = app(Filesystem::class);
+    $paths      = [
+        feedPath('ExistingScaffoldFeed'),
+        feedPath('Items/ExistingScaffoldFeedItem'),
+        feedPath('Info/ExistingScaffoldFeedInfo'),
+    ];
+    $operationPath = (string) config('deploy-operations.path');
+
+    $filesystem->ensureDirectoryExists(dirname($paths[0]));
+    $filesystem->put($paths[0], '<?php');
+    $filesystem->deleteDirectory($operationPath);
+
+    try {
+        $status = artisan(FeedMakeCommand::class, [
+            'name'   => 'ExistingScaffold',
+            '--item' => true,
+            '--info' => true,
+        ])
+            ->expectsOutputToContain('Feed already exists.')
+            ->run();
+
+        expect([
+            'status'            => $status,
+            'item_created'      => $filesystem->exists($paths[1]),
+            'info_created'      => $filesystem->exists($paths[2]),
+            'operation_created' => $filesystem->isDirectory($operationPath),
+        ])->toBe([
+            'status'            => Command::FAILURE,
+            'item_created'      => false,
+            'info_created'      => false,
+            'operation_created' => false,
+        ]);
+    } finally {
+        $filesystem->delete($paths);
+        $filesystem->deleteDirectory($operationPath);
+    }
+});
+
+test('stops scaffolding when the feed name is reserved', function () {
+    mockOperations(false);
+
+    $filesystem = app(Filesystem::class);
+    $paths      = [
+        feedPath('ClassFeed'),
+        feedPath('Items/ClassFeedItem'),
+        feedPath('Info/ClassFeedInfo'),
+    ];
+    $migrationPath = database_path('migrations');
+
+    $filesystem->deleteDirectory($migrationPath);
+
+    try {
+        $status = artisan(FeedMakeCommand::class, [
+            'name'   => 'class',
+            '--item' => true,
+            '--info' => true,
+        ])
+            ->expectsOutputToContain('The name "class" is reserved by PHP.')
+            ->run();
+
+        expect([
+            'status'            => $status,
+            'feed_created'      => $filesystem->exists($paths[0]),
+            'item_created'      => $filesystem->exists($paths[1]),
+            'info_created'      => $filesystem->exists($paths[2]),
+            'migration_created' => $filesystem->isDirectory($migrationPath),
+        ])->toBe([
+            'status'            => Command::FAILURE,
+            'feed_created'      => false,
+            'item_created'      => false,
+            'info_created'      => false,
+            'migration_created' => false,
+        ]);
+    } finally {
+        $filesystem->delete($paths);
+        $filesystem->deleteDirectory($migrationPath);
+    }
+});


### PR DESCRIPTION
## Summary

- stop `make:feed` immediately when the parent generator rejects an existing or reserved feed class
- return explicit failure and success command statuses
- cover duplicate and reserved-name failures without creating item, info, operation, or migration artifacts

## Root cause

`FeedMakeCommand::handle()` ignored the `false` result from `GeneratorCommand::handle()`. The composite command therefore continued generating dependent artifacts and eventually returned a successful exit status.

## Impact

Failed primary feed generation no longer leaves partial scaffolding or registration files behind. Successful generation behavior remains unchanged.

## Validation

- regression test: 2 passed, 4 assertions
- console tests: 9 passed, 33 assertions
- full test suite: 256 passed, 45 incomplete, 1436 assertions
- coverage: 95.8%
- type coverage: 100%
- Pint passed
- `composer validate --strict --no-check-publish` passed

Closes #195