### PR TITLE
Fix split-feed publication ownership

### DIFF
--- a/.ai-factory/patches/2026-07-22-18.55.md
+++ b/.ai-factory/patches/2026-07-22-18.55.md
@@ -1,0 +1,29 @@
+# Split-feed cleanup treated numeric siblings as owned
+
+**Date:** 2026-07-22 18:55
+**Files:** src/Services/FilesystemService.php, tests/Feature/Feeds/StorageTest.php, tests/Unit/Services/FilesystemServiceTest.php
+**Severity:** high
+
+## Problem
+
+Publishing `catalog.json` classified every sibling matching `catalog-<number>.json` as a previous split part. A successful one-file publication moved those files into staging and deleted them with the staging directory, even when another feed owned them.
+
+## Root Cause
+
+The publication transaction inferred ownership from a filename pattern. The pattern was valid for target validation but could not prove that the current feed created an existing file. Local and Flysystem cleanup used the same unsafe inference.
+
+## Solution
+
+Publication ownership is now stored in a versioned registry on the output disk. The registry maps exact target filenames to their root publication, is validated under a shared directory lock, and participates in backup, installation, and rollback. Cleanup uses only registered targets. Occupied targets without matching ownership fail before any published file is moved.
+
+## Prevention
+
+- Never infer ownership from filename shape.
+- Keep publication metadata on the same filesystem as the published files.
+- Validate metadata before moving targets.
+- Commit ownership metadata last and restore it with the published files on failure.
+- Cover independent numeric siblings, cross-feed conflicts, invalid metadata, obsolete owned parts, and metadata rollback on local and remote disks.
+
+## Tags
+
+`#filesystem` `#ownership` `#split-feed` `#flysystem` `#rollback` `#issue-196`

--- a/src/Services/FilesystemService.php
+++ b/src/Services/FilesystemService.php
@@ -346,7 +346,7 @@ class FilesystemService
 
         $this->assertStorageOwnership($storage, $path, $targets, $ownership);
 
-        $existing      = $this->storageOwnedPaths($path, $ownership);
+        $existing      = $this->storageOwnedPaths($storage, $path, $ownership);
         $nextOwnership = $this->nextStorageOwnership($path, $targets, $ownership);
 
         $cleanup   = true;
@@ -800,16 +800,21 @@ class FilesystemService
         return $this->publicationOwnedPaths(
             $path,
             $ownership,
+            fn (string $target)   => $this->file->exists($target),
             fn (string $filename) => $this->pathInDirectory($path, $filename),
             fn (string $target)   => $this->pathKey($target),
         );
     }
 
-    protected function storageOwnedPaths(string $path, array $ownership): array
-    {
+    protected function storageOwnedPaths(
+        FilesystemOperator $storage,
+        string $path,
+        array $ownership,
+    ): array {
         return $this->publicationOwnedPaths(
             $path,
             $ownership,
+            fn (string $target)   => $storage->fileExists($target),
             fn (string $filename) => $this->storagePathInDirectory($path, $filename),
             fn (string $target)   => $this->storagePathKey($target),
         );
@@ -818,11 +823,16 @@ class FilesystemService
     protected function publicationOwnedPaths(
         string $path,
         array $ownership,
+        Closure $exists,
         Closure $resolvePath,
         Closure $pathKey,
     ): array {
         $ownerKey = $pathKey($path);
         $paths    = [];
+
+        if ($this->ownerOf($path, $ownership, $resolvePath, $pathKey) === null && $exists($path)) {
+            $paths[] = $path;
+        }
 
         foreach ($ownership as $target => $owner) {
             if ($pathKey($resolvePath($owner)) === $ownerKey) {

--- a/src/Services/FilesystemService.php
+++ b/src/Services/FilesystemService.php
@@ -32,6 +32,9 @@ use function implode;
 use function is_array;
 use function is_resource;
 use function is_string;
+use function json_decode;
+use function json_encode;
+use function ksort;
 use function pathinfo;
 use function preg_match;
 use function preg_quote;
@@ -39,6 +42,7 @@ use function random_bytes;
 use function realpath;
 use function sort;
 use function storage_path;
+use function str_contains;
 use function str_replace;
 use function stream_get_meta_data;
 use function strlen;
@@ -48,7 +52,11 @@ use function sys_get_temp_dir;
 
 class FilesystemService
 {
-    protected const MAX_PATH_ATTEMPTS = 10;
+    protected const MAX_PATH_ATTEMPTS   = 10;
+    protected const OWNERSHIP_DIRECTORY = '.laravel-feeds';
+    protected const OWNERSHIP_FILENAME  = 'ownership.json';
+    protected const OWNERSHIP_FORMAT    = 'dragon-code/laravel-feeds-ownership';
+    protected const OWNERSHIP_VERSION   = 1;
 
     public function __construct(
         protected File $file,
@@ -200,7 +208,12 @@ class FilesystemService
                     throw new RuntimeException('The publication callback must return an array of staged files.');
                 }
 
-                $this->commit($path, $drafts, $staging->path(), $cleanup);
+                $this->lock(
+                    $this->ownershipPath($path),
+                    function () use ($drafts, $path, $staging, &$cleanup) {
+                        $this->commit($path, $drafts, $staging->path(), $cleanup);
+                    }
+                );
             } catch (Throwable $e) {
                 $failure = $e;
             }
@@ -228,8 +241,11 @@ class FilesystemService
     {
         $filesystem = $storage->getDriver();
         $lock       = get_class($storage->getAdapter()) . ':' . $storage->path($path);
+        $ownership  = get_class($storage->getAdapter()) . ':' . $storage->path(
+            $this->storageOwnershipPath($path)
+        );
 
-        $this->lock($lock, function () use ($callback, $filesystem, $path) {
+        $this->lock($lock, function () use ($callback, $filesystem, $ownership, $path) {
             $localStaging = $this->createTemporaryDirectory(
                 sys_get_temp_dir(),
                 fn () => 'laravel_feeds_' . $this->uniqueIdentifier()
@@ -241,7 +257,12 @@ class FilesystemService
             try {
                 $drafts = $callback($localStaging->path());
 
-                $this->commitStorage($filesystem, $path, $drafts, $remoteStaging, $cleanupRemote);
+                $this->lock(
+                    $ownership,
+                    function () use ($drafts, $filesystem, $path, $remoteStaging, &$cleanupRemote) {
+                        $this->commitStorage($filesystem, $path, $drafts, $remoteStaging, $cleanupRemote);
+                    }
+                );
             } catch (Throwable $e) {
                 $failure = $e;
             }
@@ -318,16 +339,23 @@ class FilesystemService
         string $staging,
         bool &$cleanup,
     ): void {
-        $drafts = $this->validateStorageDrafts($path, $drafts);
+        $drafts        = $this->validateStorageDrafts($path, $drafts);
+        $targets       = array_keys($drafts);
+        $ownershipPath = $this->storageOwnershipPath($path);
+        $ownership     = $this->storageOwnership($storage, $path);
+
+        $this->assertStorageOwnership($storage, $path, $targets, $ownership);
+
+        $existing      = $this->storageOwnedPaths($path, $ownership);
+        $nextOwnership = $this->nextStorageOwnership($path, $targets, $ownership);
 
         $cleanup   = true;
         $backups   = [];
         $installed = [];
 
         try {
-            $drafts   = $this->stageStorageDrafts($storage, $drafts, $staging);
-            $existing = $this->publishedStoragePaths($storage, $path);
-            $targets  = array_keys($drafts);
+            $drafts         = $this->stageStorageDrafts($storage, $drafts, $staging);
+            $ownershipDraft = $this->stageStorageOwnership($storage, $nextOwnership, $staging);
 
             foreach ($drafts as $target => $draft) {
                 if ($storage->fileExists($target)) {
@@ -352,6 +380,23 @@ class FilesystemService
 
                 $storage->move($published, $backup);
             }
+
+            if ($storage->fileExists($ownershipPath)) {
+                $backup                  = $this->storageBackupPath($storage, $staging);
+                $backups[$ownershipPath] = $backup;
+
+                $storage->move($ownershipPath, $backup);
+            }
+
+            $ownershipDirectory = $this->storageDirectory($ownershipPath);
+
+            if (! $storage->directoryExists($ownershipDirectory)) {
+                $storage->createDirectory($ownershipDirectory);
+            }
+
+            $installed[] = $ownershipPath;
+
+            $storage->move($ownershipDraft, $ownershipPath);
         } catch (Throwable $e) {
             $rollbackFailure = $this->rollbackStorage($storage, $installed, $backups);
 
@@ -374,9 +419,16 @@ class FilesystemService
 
     protected function commit(string $path, array $drafts, string $staging, bool &$cleanup): void
     {
-        $drafts   = $this->validateDrafts($path, $drafts);
-        $existing = $this->publishedPaths($path);
-        $targets  = array_keys($drafts);
+        $drafts        = $this->validateDrafts($path, $drafts);
+        $targets       = array_keys($drafts);
+        $ownershipPath = $this->ownershipPath($path);
+        $ownership     = $this->ownership($path);
+
+        $this->assertOwnership($path, $targets, $ownership);
+
+        $existing       = $this->ownedPaths($path, $ownership);
+        $nextOwnership  = $this->nextOwnership($path, $targets, $ownership);
+        $ownershipDraft = $this->ownershipDraft($ownershipPath, $nextOwnership, $staging);
 
         $backups   = [];
         $installed = [];
@@ -403,6 +455,24 @@ class FilesystemService
 
                 $backups[$published] = $this->backup($published, $staging);
             }
+
+            if ($this->file->exists($ownershipPath)) {
+                $backups[$ownershipPath] = $this->backup($ownershipPath, $staging);
+            }
+
+            $this->file->ensureDirectoryExists(dirname($ownershipPath));
+
+            if (! $this->file->isDirectory(dirname($ownershipPath))) {
+                throw new RuntimeException(
+                    'Unable to create the feed ownership directory: [' . dirname($ownershipPath) . '].'
+                );
+            }
+
+            if (! $this->file->move($ownershipDraft, $ownershipPath)) {
+                throw new RuntimeException("Unable to publish the feed ownership registry: [$ownershipPath].");
+            }
+
+            $installed[] = $ownershipPath;
         } catch (Throwable $e) {
             $rollbackFailure = $this->rollback($installed, $backups);
 
@@ -547,23 +617,216 @@ class FilesystemService
         return DIRECTORY_SEPARATOR === '\\' ? strtolower($path) : $path;
     }
 
-    protected function publishedStoragePaths(FilesystemOperator $storage, string $path): array
+    protected function ownership(string $path): array
     {
-        $paths = [];
+        $ownershipPath = $this->ownershipPath($path);
 
-        if ($storage->fileExists($path)) {
-            $paths[] = $path;
+        if (! $this->file->exists($ownershipPath)) {
+            return [];
         }
 
-        foreach ($storage->listContents($this->storageDirectory($path), false) as $file) {
-            if (! $file->isFile()) {
+        try {
+            if (! $this->file->isFile($ownershipPath)) {
+                throw new RuntimeException("Feed ownership registry is not a file: [$ownershipPath].");
+            }
+
+            return $this->decodeOwnership(
+                $this->file->get($ownershipPath),
+                fn (string $filename) => $this->pathInDirectory($path, $filename),
+                fn (string $target)   => $this->pathKey($target),
+            );
+        } catch (Throwable $e) {
+            throw new RuntimeException(
+                "Unable to read a valid feed ownership registry: [$ownershipPath].",
+                previous: $e
+            );
+        }
+    }
+
+    protected function storageOwnership(FilesystemOperator $storage, string $path): array
+    {
+        $ownershipPath = $this->storageOwnershipPath($path);
+
+        if (! $storage->fileExists($ownershipPath)) {
+            if ($storage->directoryExists($ownershipPath)) {
+                throw new RuntimeException("Unable to read a valid feed ownership registry: [$ownershipPath].");
+            }
+
+            return [];
+        }
+
+        try {
+            return $this->decodeOwnership(
+                $storage->read($ownershipPath),
+                fn (string $filename) => $this->storagePathInDirectory($path, $filename),
+                fn (string $target)   => $this->storagePathKey($target),
+            );
+        } catch (Throwable $e) {
+            throw new RuntimeException(
+                "Unable to read a valid feed ownership registry: [$ownershipPath].",
+                previous: $e
+            );
+        }
+    }
+
+    protected function decodeOwnership(string $contents, Closure $resolvePath, Closure $pathKey): array
+    {
+        $decoded = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+        $keys    = is_array($decoded) ? array_keys($decoded) : [];
+
+        sort($keys);
+
+        if (
+            $keys                  !== ['format', 'owners', 'version']
+            || $decoded['format']  !== self::OWNERSHIP_FORMAT
+            || $decoded['version'] !== self::OWNERSHIP_VERSION
+            || ! is_array($decoded['owners'])
+        ) {
+            throw new RuntimeException('Unsupported feed ownership registry.');
+        }
+
+        $targets = [];
+
+        foreach ($decoded['owners'] as $target => $owner) {
+            if (
+                ! is_string($target)
+                || ! is_string($owner)
+                || ! $this->isOwnershipFilename($target)
+                || ! $this->isOwnershipFilename($owner)
+                || ($target !== $owner && ! $this->matchesSplitFilename($target, $owner))
+            ) {
+                throw new RuntimeException('Invalid feed ownership entry.');
+            }
+
+            $targetKey = $pathKey($resolvePath($target));
+
+            if (isset($targets[$targetKey])) {
+                throw new RuntimeException('Duplicate feed ownership entry.');
+            }
+
+            $targets[$targetKey] = true;
+        }
+
+        $ownership = $decoded['owners'];
+
+        ksort($ownership, SORT_NATURAL);
+
+        return $ownership;
+    }
+
+    protected function isOwnershipFilename(string $filename): bool
+    {
+        return $filename !== ''
+            && $filename !== '.'
+            && $filename !== '..'
+            && ! str_contains($filename, '/')
+            && ! str_contains($filename, '\\');
+    }
+
+    protected function assertOwnership(string $path, array $targets, array $ownership): void
+    {
+        $this->assertOwnedTargets(
+            $path,
+            $targets,
+            $ownership,
+            fn (string $target)   => $this->file->exists($target),
+            fn (string $filename) => $this->pathInDirectory($path, $filename),
+            fn (string $target)   => $this->pathKey($target),
+        );
+    }
+
+    protected function assertStorageOwnership(
+        FilesystemOperator $storage,
+        string $path,
+        array $targets,
+        array $ownership,
+    ): void {
+        $this->assertOwnedTargets(
+            $path,
+            $targets,
+            $ownership,
+            fn (string $target)   => $storage->fileExists($target),
+            fn (string $filename) => $this->storagePathInDirectory($path, $filename),
+            fn (string $target)   => $this->storagePathKey($target),
+        );
+    }
+
+    protected function assertOwnedTargets(
+        string $path,
+        array $targets,
+        array $ownership,
+        Closure $exists,
+        Closure $resolvePath,
+        Closure $pathKey,
+    ): void {
+        $publicationKey = $pathKey($path);
+
+        foreach ($targets as $target) {
+            $owner = $this->ownerOf($target, $ownership, $resolvePath, $pathKey);
+
+            if ($owner !== null) {
+                if ($pathKey($owner) !== $publicationKey) {
+                    throw new RuntimeException("Feed publication target is not owned: [$target].");
+                }
+
                 continue;
             }
 
-            $candidate = $file->path();
+            if ($pathKey($target) !== $publicationKey && $exists($target)) {
+                throw new RuntimeException("Feed publication target is not owned: [$target].");
+            }
+        }
+    }
 
-            if ($this->matchesSplitFilename(basename($candidate), basename($path))) {
-                $paths[] = $candidate;
+    protected function ownerOf(
+        string $target,
+        array $ownership,
+        Closure $resolvePath,
+        Closure $pathKey,
+    ): ?string {
+        $targetKey = $pathKey($target);
+
+        foreach ($ownership as $owned => $owner) {
+            if ($pathKey($resolvePath($owned)) === $targetKey) {
+                return $resolvePath($owner);
+            }
+        }
+
+        return null;
+    }
+
+    protected function ownedPaths(string $path, array $ownership): array
+    {
+        return $this->publicationOwnedPaths(
+            $path,
+            $ownership,
+            fn (string $filename) => $this->pathInDirectory($path, $filename),
+            fn (string $target)   => $this->pathKey($target),
+        );
+    }
+
+    protected function storageOwnedPaths(string $path, array $ownership): array
+    {
+        return $this->publicationOwnedPaths(
+            $path,
+            $ownership,
+            fn (string $filename) => $this->storagePathInDirectory($path, $filename),
+            fn (string $target)   => $this->storagePathKey($target),
+        );
+    }
+
+    protected function publicationOwnedPaths(
+        string $path,
+        array $ownership,
+        Closure $resolvePath,
+        Closure $pathKey,
+    ): array {
+        $ownerKey = $pathKey($path);
+        $paths    = [];
+
+        foreach ($ownership as $target => $owner) {
+            if ($pathKey($resolvePath($owner)) === $ownerKey) {
+                $paths[] = $resolvePath($target);
             }
         }
 
@@ -572,23 +835,122 @@ class FilesystemService
         return $paths;
     }
 
-    protected function publishedPaths(string $path): array
+    protected function nextOwnership(string $path, array $targets, array $ownership): array
     {
-        $paths = [];
+        return $this->nextPublicationOwnership(
+            $path,
+            $targets,
+            $ownership,
+            fn (string $filename) => $this->pathInDirectory($path, $filename),
+            fn (string $target)   => $this->pathKey($target),
+        );
+    }
 
-        if ($this->file->exists($path)) {
-            $paths[] = $path;
-        }
+    protected function nextStorageOwnership(string $path, array $targets, array $ownership): array
+    {
+        return $this->nextPublicationOwnership(
+            $path,
+            $targets,
+            $ownership,
+            fn (string $filename) => $this->storagePathInDirectory($path, $filename),
+            fn (string $target)   => $this->storagePathKey($target),
+        );
+    }
 
-        foreach ($this->file->files(dirname($path)) as $file) {
-            if ($this->matchesSplitFilename($file->getFilename(), basename($path))) {
-                $paths[] = $file->getPathname();
+    protected function nextPublicationOwnership(
+        string $path,
+        array $targets,
+        array $ownership,
+        Closure $resolvePath,
+        Closure $pathKey,
+    ): array {
+        $ownerKey = $pathKey($path);
+
+        foreach ($ownership as $target => $owner) {
+            if ($pathKey($resolvePath($owner)) === $ownerKey) {
+                unset($ownership[$target]);
             }
         }
 
-        sort($paths, SORT_NATURAL);
+        foreach ($targets as $target) {
+            $targetKey = $pathKey($target);
 
-        return $paths;
+            foreach ($ownership as $owned => $owner) {
+                if ($pathKey($resolvePath($owned)) === $targetKey) {
+                    unset($ownership[$owned]);
+                }
+            }
+
+            $ownership[basename($target)] = $targetKey === $ownerKey
+                ? basename($target)
+                : basename($path);
+        }
+
+        ksort($ownership, SORT_NATURAL);
+
+        return $ownership;
+    }
+
+    protected function ownershipDraft(string $path, array $ownership, string $staging): string
+    {
+        $draft = $this->createDraft(basename($path), $staging);
+
+        try {
+            $this->append($draft, $this->encodeOwnership($ownership), $path);
+
+            return $this->finishDraft($draft);
+        } catch (Throwable $e) {
+            $this->close($draft);
+
+            throw $e;
+        }
+    }
+
+    protected function stageStorageOwnership(
+        FilesystemOperator $storage,
+        array $ownership,
+        string $staging,
+    ): string {
+        $path = $staging . '/ownership/' . $this->uniqueIdentifier();
+
+        $storage->write($path, $this->encodeOwnership($ownership));
+
+        return $path;
+    }
+
+    protected function encodeOwnership(array $ownership): string
+    {
+        return json_encode([
+            'format'  => self::OWNERSHIP_FORMAT,
+            'version' => self::OWNERSHIP_VERSION,
+            'owners'  => $ownership,
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "\n";
+    }
+
+    protected function ownershipPath(string $path): string
+    {
+        return dirname($path) . DIRECTORY_SEPARATOR . self::OWNERSHIP_DIRECTORY
+            . DIRECTORY_SEPARATOR . self::OWNERSHIP_FILENAME;
+    }
+
+    protected function storageOwnershipPath(string $path): string
+    {
+        return $this->storagePathInDirectory(
+            $path,
+            self::OWNERSHIP_DIRECTORY . '/' . self::OWNERSHIP_FILENAME
+        );
+    }
+
+    protected function pathInDirectory(string $path, string $filename): string
+    {
+        return dirname($path) . DIRECTORY_SEPARATOR . $filename;
+    }
+
+    protected function storagePathInDirectory(string $path, string $filename): string
+    {
+        $directory = $this->storageDirectory($path);
+
+        return $directory === '' ? $filename : "$directory/$filename";
     }
 
     protected function rollback(array $installed, array $backups): ?Throwable

--- a/tests/Feature/Feeds/StorageTest.php
+++ b/tests/Feature/Feeds/StorageTest.php
@@ -373,6 +373,30 @@ test('replaces remote feeds and removes obsolete split parts', function () {
         ->toBe([]);
 });
 
+test('removes a pre-registry remote primary file when publishing split parts', function () {
+    $storage     = app(RemoteStorageFeed::class)->storage();
+    $filesystem  = app(FilesystemService::class);
+    $publication = 'exports/legacy.jsonl';
+    $first       = 'exports/legacy-1.jsonl';
+    $second      = 'exports/legacy-2.jsonl';
+
+    $storage->put($publication, 'legacy-primary');
+
+    $filesystem->publishTo($storage, $publication, static fn (string $staging) => [
+        $first  => remoteFeedDraft($staging, 'first'),
+        $second => remoteFeedDraft($staging, 'second'),
+    ]);
+
+    expect($storage->exists($publication))
+        ->toBeFalse()
+        ->and($storage->get($first))
+        ->toBe('first')
+        ->and($storage->get($second))
+        ->toBe('second')
+        ->and(remoteStagingFiles($storage))
+        ->toBe([]);
+});
+
 test('validates remote publication drafts', function () {
     $storage     = app(RemoteStorageFeed::class)->storage();
     $filesystem  = app(FilesystemService::class);

--- a/tests/Feature/Feeds/StorageTest.php
+++ b/tests/Feature/Feeds/StorageTest.php
@@ -29,6 +29,8 @@ use Workbench\App\Models\News;
 
 final class RemoteFeedFilesystemAdapter extends DecoratedAdapter
 {
+    public array $moves = [];
+
     public int $streamWrites = 0;
 
     protected ?string $failedDestination = null;
@@ -83,6 +85,8 @@ final class RemoteFeedFilesystemAdapter extends DecoratedAdapter
 
     public function move(string $source, string $destination, Config $config): void
     {
+        $this->moves[] = [$source, $destination];
+
         if ($this->failedDestination === $destination) {
             $this->failedDestination = null;
 
@@ -288,6 +292,22 @@ test('restores remote feed parts when publication fails', function () {
 
     expect(remoteStagingFiles($storage))->toBe([]);
 
+    $ownership = dirname($feed->storagePath()) . '/.laravel-feeds/ownership.json';
+
+    RemoteFeedStorage::$adapter->failNextMoveTo($ownership);
+
+    expect(fn () => $generator->feed($feed))
+        ->toThrow(FeedGenerationException::class, $ownership);
+
+    foreach ($published as $path => $content) {
+        expect($storage->get($path))->toBe($content);
+    }
+
+    expect($storage->exists($ownership))
+        ->toBeTrue()
+        ->and(remoteStagingFiles($storage))
+        ->toBe([]);
+
     Event::assertNotDispatched(FeedFinishedEvent::class);
 });
 
@@ -321,6 +341,34 @@ test('replaces remote feeds and removes obsolete split parts', function () {
 
     expect($storage->get($feed->storagePath()))
         ->not->toBe('old-single')
+        ->and(remoteStagingFiles($storage))
+        ->toBe([]);
+
+    $independent = $feed->storagePath(1);
+
+    $storage->put($independent, 'independent');
+
+    $generator->feed($feed);
+
+    $published = $storage->get($feed->storagePath());
+    $moveCount = count(RemoteFeedStorage::$adapter->moves);
+
+    expect($storage->get($independent))->toBe('independent');
+
+    RemoteStorageFeed::$perFile = 1;
+
+    expect(fn () => $generator->feed($feed))
+        ->toThrow(
+            FeedGenerationException::class,
+            "Feed publication target is not owned: [$independent]."
+        );
+
+    expect($storage->get($feed->storagePath()))
+        ->toBe($published)
+        ->and($storage->get($independent))
+        ->toBe('independent')
+        ->and(RemoteFeedStorage::$adapter->moves)
+        ->toHaveCount($moveCount)
         ->and(remoteStagingFiles($storage))
         ->toBe([]);
 });

--- a/tests/Unit/Services/FilesystemServiceTest.php
+++ b/tests/Unit/Services/FilesystemServiceTest.php
@@ -578,6 +578,40 @@ test('removes only obsolete numeric split parts after a successful commit', func
     }
 });
 
+test('removes a pre-registry primary file when publishing split parts', function () {
+    $directory   = (new TemporaryDirectory)->create();
+    $publication = $directory->path('feed.json');
+    $first       = $directory->path('feed-1.json');
+    $second      = $directory->path('feed-2.json');
+    $service     = new FilesystemService(new Filesystem);
+
+    file_put_contents($publication, 'legacy-primary');
+
+    try {
+        $service->publish($publication, function (string $staging) use ($first, $second, $service) {
+            $firstDraft = $service->createDraft('feed.json', $staging);
+            $service->append($firstDraft, 'first', $first);
+
+            $secondDraft = $service->createDraft('feed.json', $staging);
+            $service->append($secondDraft, 'second', $second);
+
+            return [
+                $first  => $service->finishDraft($firstDraft),
+                $second => $service->finishDraft($secondDraft),
+            ];
+        });
+
+        expect($publication)
+            ->not->toBeFile()
+            ->and(file_get_contents($first))
+            ->toBe('first')
+            ->and(file_get_contents($second))
+            ->toBe('second');
+    } finally {
+        $directory->delete();
+    }
+});
+
 test('preserves an unowned numeric sibling and rejects it as a split target', function () {
     $directory   = (new TemporaryDirectory)->create();
     $publication = $directory->path('catalog.json');
@@ -652,6 +686,37 @@ test('rejects a primary target owned by another feed publication', function () {
             ->toBe('owned-split')
             ->and(glob($directory->path() . DIRECTORY_SEPARATOR . '.feeds_staging_*'))
             ->toBe([]);
+    } finally {
+        $directory->delete();
+    }
+});
+
+test('preserves a primary path owned by another publication when publishing split parts', function () {
+    $directory   = (new TemporaryDirectory)->create();
+    $root        = $directory->path('catalog.json');
+    $publication = $directory->path('catalog-1.json');
+    $nested      = $directory->path('catalog-1-1.json');
+    $service     = new FilesystemService(new Filesystem);
+
+    try {
+        $service->publish($root, function (string $staging) use ($publication, $service) {
+            $draft = $service->createDraft('catalog.json', $staging);
+            $service->append($draft, 'parent-feed', $publication);
+
+            return [$publication => $service->finishDraft($draft)];
+        });
+
+        $service->publish($publication, function (string $staging) use ($nested, $service) {
+            $draft = $service->createDraft('catalog-1.json', $staging);
+            $service->append($draft, 'nested-feed', $nested);
+
+            return [$nested => $service->finishDraft($draft)];
+        });
+
+        expect(file_get_contents($publication))
+            ->toBe('parent-feed')
+            ->and(file_get_contents($nested))
+            ->toBe('nested-feed');
     } finally {
         $directory->delete();
     }

--- a/tests/Unit/Services/FilesystemServiceTest.php
+++ b/tests/Unit/Services/FilesystemServiceTest.php
@@ -52,6 +52,8 @@ final class ControlledWriteStream
 
 final class ControlledMoveFilesystem extends Filesystem
 {
+    public array $moves = [];
+
     protected array $moveFailures = [];
 
     public function failNextMoveTo(string $path): void
@@ -61,6 +63,8 @@ final class ControlledMoveFilesystem extends Filesystem
 
     public function move($path, $target)
     {
+        $this->moves[] = [$path, $target];
+
         if (isset($this->moveFailures[$target])) {
             unset($this->moveFailures[$target]);
 
@@ -402,7 +406,14 @@ test('retries staging creation without removing the colliding directory', functi
     mkdir($collision);
     file_put_contents($sentinel, 'existing');
 
-    ControlledIdentifierFilesystemService::reset('collision', 'staging', 'draft_directory', 'draft_file');
+    ControlledIdentifierFilesystemService::reset(
+        'collision',
+        'staging',
+        'draft_directory',
+        'draft_file',
+        'ownership_directory',
+        'ownership_file'
+    );
 
     try {
         $service = new ControlledIdentifierFilesystemService(new Filesystem);
@@ -450,12 +461,22 @@ test('restores every published part when a staged move fails', function () {
     $file        = new ControlledMoveFilesystem;
     $service     = new FilesystemService($file);
 
-    file_put_contents($first, 'old-first');
-    file_put_contents($second, 'old-second');
-
-    $file->failNextMoveTo($second);
-
     try {
+        $service->publish($publication, function (string $staging) use ($first, $second, $service) {
+            $firstDraft = $service->createDraft('feed.json', $staging);
+            $service->append($firstDraft, 'old-first', $first);
+
+            $secondDraft = $service->createDraft('feed.json', $staging);
+            $service->append($secondDraft, 'old-second', $second);
+
+            return [
+                $first  => $service->finishDraft($firstDraft),
+                $second => $service->finishDraft($secondDraft),
+            ];
+        });
+
+        $file->failNextMoveTo($second);
+
         expect(fn () => $service->publish($publication, function (string $staging) use ($first, $second, $service) {
             $firstDraft = $service->createDraft('feed.json', $staging);
             $service->append($firstDraft, 'new-first', $first);
@@ -517,13 +538,24 @@ test('removes only obsolete numeric split parts after a successful commit', func
     $unrelated   = $directory->path('feed-copy.json');
     $service     = new FilesystemService(new Filesystem);
 
-    foreach (range(1, 3) as $index) {
-        file_put_contents($directory->path("feed-$index.json"), "old-$index");
-    }
-
-    file_put_contents($unrelated, 'unrelated');
-
     try {
+        $service->publish($publication, function (string $staging) use ($directory, $service) {
+            $drafts = [];
+
+            foreach (range(1, 3) as $index) {
+                $target = $directory->path("feed-$index.json");
+                $draft  = $service->createDraft('feed.json', $staging);
+
+                $service->append($draft, "old-$index", $target);
+
+                $drafts[$target] = $service->finishDraft($draft);
+            }
+
+            return $drafts;
+        });
+
+        file_put_contents($unrelated, 'unrelated');
+
         $service->publish($publication, function (string $staging) use ($publication, $service) {
             $draft = $service->createDraft('feed.json', $staging);
             $service->append($draft, 'new', $publication);
@@ -541,6 +573,160 @@ test('removes only obsolete numeric split parts after a successful commit', func
             ->not->toBeFile()
             ->and(file_get_contents($unrelated))
             ->toBe('unrelated');
+    } finally {
+        $directory->delete();
+    }
+});
+
+test('preserves an unowned numeric sibling and rejects it as a split target', function () {
+    $directory   = (new TemporaryDirectory)->create();
+    $publication = $directory->path('catalog.json');
+    $independent = $directory->path('catalog-1.json');
+    $file        = new ControlledMoveFilesystem;
+    $service     = new FilesystemService($file);
+
+    file_put_contents($independent, 'independent');
+
+    try {
+        $service->publish($publication, function (string $staging) use ($publication, $service) {
+            $draft = $service->createDraft('catalog.json', $staging);
+            $service->append($draft, 'published', $publication);
+
+            return [$publication => $service->finishDraft($draft)];
+        });
+
+        expect($publication)
+            ->toBeFile()
+            ->and(file_get_contents($publication))
+            ->toBe('published')
+            ->and($independent)
+            ->toBeFile()
+            ->and(file_get_contents($independent))
+            ->toBe('independent')
+            ->and(array_column($file->moves, 0))
+            ->not->toContain($independent);
+
+        expect(fn () => $service->publish(
+            $publication,
+            function (string $staging) use ($independent, $service) {
+                $draft = $service->createDraft('catalog.json', $staging);
+                $service->append($draft, 'split', $independent);
+
+                return [$independent => $service->finishDraft($draft)];
+            }
+        ))->toThrow(RuntimeException::class, "Feed publication target is not owned: [$independent].");
+
+        expect(file_get_contents($publication))
+            ->toBe('published')
+            ->and(file_get_contents($independent))
+            ->toBe('independent')
+            ->and(glob($directory->path() . DIRECTORY_SEPARATOR . '.feeds_staging_*'))
+            ->toBe([]);
+    } finally {
+        $directory->delete();
+    }
+});
+
+test('rejects a primary target owned by another feed publication', function () {
+    $directory   = (new TemporaryDirectory)->create();
+    $publication = $directory->path('catalog.json');
+    $split       = $directory->path('catalog-1.json');
+    $service     = new FilesystemService(new Filesystem);
+
+    try {
+        $service->publish($publication, function (string $staging) use ($service, $split) {
+            $draft = $service->createDraft('catalog.json', $staging);
+            $service->append($draft, 'owned-split', $split);
+
+            return [$split => $service->finishDraft($draft)];
+        });
+
+        expect(fn () => $service->publish($split, function (string $staging) use ($service, $split) {
+            $draft = $service->createDraft('catalog-1.json', $staging);
+            $service->append($draft, 'other-feed', $split);
+
+            return [$split => $service->finishDraft($draft)];
+        }))
+            ->toThrow(RuntimeException::class, "Feed publication target is not owned: [$split].")
+            ->and(file_get_contents($split))
+            ->toBe('owned-split')
+            ->and(glob($directory->path() . DIRECTORY_SEPARATOR . '.feeds_staging_*'))
+            ->toBe([]);
+    } finally {
+        $directory->delete();
+    }
+});
+
+test('restores the feed and ownership registry when registry installation fails', function () {
+    $directory   = (new TemporaryDirectory)->create();
+    $publication = $directory->path('feed.json');
+    $ownership   = $directory->path('.laravel-feeds' . DIRECTORY_SEPARATOR . 'ownership.json');
+    $file        = new ControlledMoveFilesystem;
+    $service     = new FilesystemService($file);
+
+    try {
+        $service->publish($publication, function (string $staging) use ($publication, $service) {
+            $draft = $service->createDraft('feed.json', $staging);
+            $service->append($draft, 'old', $publication);
+
+            return [$publication => $service->finishDraft($draft)];
+        });
+
+        $file->failNextMoveTo($ownership);
+
+        expect(fn () => $service->publish($publication, function (string $staging) use ($publication, $service) {
+            $draft = $service->createDraft('feed.json', $staging);
+            $service->append($draft, 'new', $publication);
+
+            return [$publication => $service->finishDraft($draft)];
+        }))
+            ->toThrow(CloseFeedException::class, 'Unable to publish the feed ownership registry:')
+            ->and(file_get_contents($publication))
+            ->toBe('old')
+            ->and($ownership)
+            ->toBeFile();
+
+        $service->publish($publication, function (string $staging) use ($publication, $service) {
+            $draft = $service->createDraft('feed.json', $staging);
+            $service->append($draft, 'after-rollback', $publication);
+
+            return [$publication => $service->finishDraft($draft)];
+        });
+
+        expect(file_get_contents($publication))->toBe('after-rollback');
+    } finally {
+        $directory->delete();
+    }
+});
+
+test('rejects an invalid ownership registry before moving publication files', function () {
+    $directory   = (new TemporaryDirectory)->create();
+    $publication = $directory->path('feed.json');
+    $ownership   = $directory->path('.laravel-feeds' . DIRECTORY_SEPARATOR . 'ownership.json');
+    $file        = new ControlledMoveFilesystem;
+    $service     = new FilesystemService($file);
+
+    if (! is_dir(dirname($ownership))) {
+        mkdir(dirname($ownership));
+    }
+    file_put_contents($ownership, 'invalid');
+
+    try {
+        expect(fn () => $service->publish($publication, function (string $staging) use ($publication, $service) {
+            $draft = $service->createDraft('feed.json', $staging);
+            $service->append($draft, 'new', $publication);
+
+            return [$publication => $service->finishDraft($draft)];
+        }))
+            ->toThrow(RuntimeException::class, 'Unable to read a valid feed ownership registry:')
+            ->and($publication)
+            ->not->toBeFile()
+            ->and(file_get_contents($ownership))
+            ->toBe('invalid')
+            ->and($file->moves)
+            ->toBe([])
+            ->and(glob($directory->path() . DIRECTORY_SEPARATOR . '.feeds_staging_*'))
+            ->toBe([]);
     } finally {
         $directory->delete();
     }


### PR DESCRIPTION
## Summary

- track exact feed target ownership in a versioned per-directory registry
- reject unowned split-target conflicts before moving local or remote files
- commit and roll back ownership metadata with the published feed files
- remove a pre-registry primary output when a publication transitions to split parts

## Root cause

`FilesystemService` treated every sibling matching `<base>-<number>.<extension>` as a split part owned by the base feed. Cleanup could therefore move and delete an unrelated feed such as `catalog-1.json` while publishing `catalog.json`.

The first implementation also relied only on registry entries when finding obsolete outputs. During migration from a pre-registry single file to split parts, the old primary file was therefore left behind.

## Compatibility

Existing primary feed files remain replaceable. An unregistered primary file is treated as a legacy output of that publication and removed when it becomes obsolete. A primary registered to another publication is preserved. Legacy numeric split targets without ownership metadata are not adopted automatically; an occupied target fails explicitly instead of risking data loss.

## Validation

- targeted filesystem suite: 36 passed, 190 assertions
- full Pest suite: 263 passed, 45 incomplete, 1485 assertions
- coverage suite: 308 passed, 1601 assertions, 95.2% total coverage
- type coverage: 100.0%
- scoped Pint: passed
- `composer validate --strict --no-check-publish`: passed
- repository-wide Pint remains blocked by pre-existing line-ending/style findings outside this change

Fixes #196