### PR TITLE
fix(migrations): make feed registrations reversible

### DIFF
--- a/.ai-factory/patches/2026-07-22-23.34.md
+++ b/.ai-factory/patches/2026-07-22-23.34.md
@@ -1,0 +1,27 @@
+# New Feature test omitted its required Pest snapshot
+
+**Date:** 2026-07-22 23:34
+**Files:** tests/.pest/snapshots/Feature/Console/Make/MigrationRollbackTest/generated_feed_registration_migration_is_reversible.snap
+**Severity:** medium
+
+## Problem
+
+The migration rollback Feature test passed while creating an untracked Pest snapshot. The staged change therefore omitted a required fixture and would fail once the strict missing-snapshot gate from issue 199 is enabled.
+
+## Root Cause
+
+Every Feature test receives a global `afterEach` snapshot assertion from `tests/Pest.php`. Pest currently creates a missing snapshot without failing the command, so the new test appeared complete even though its generated fixture was not included in the change.
+
+## Solution
+
+Added the generated snapshot containing `end of snapshots` to the staged migration rollback test changes. Re-running the test leaves the snapshot hash unchanged and creates no untracked files in its snapshot directory.
+
+## Prevention
+
+- Inspect `git status --short --untracked-files=all` after adding Feature tests.
+- Include the generated end-of-snapshots fixture with every new Feature test.
+- Verify the target snapshot directory contains no untracked files after the regression test runs.
+
+## Tags
+
+`#pest` `#snapshot` `#feature-test` `#regression` `#issue-198`

--- a/src/Queries/FeedQuery.php
+++ b/src/Queries/FeedQuery.php
@@ -55,6 +55,13 @@ class FeedQuery
         Feed::destroy($id);
     }
 
+    public function deleteByClass(string $class): void
+    {
+        Feed::withTrashed()
+            ->whereClass($class)
+            ->forceDelete();
+    }
+
     public function restore(int $id): void
     {
         Feed::query()

--- a/stubs/migration.stub
+++ b/stubs/migration.stub
@@ -17,4 +17,9 @@ return new class extends Migration {
             expression: '* * * * *'
         );
     }
+
+    public function down(): void
+    {
+        app(FeedQuery::class)->deleteByClass(DummyBaseClass::class);
+    }
 };

--- a/tests/.pest/snapshots/Feature/Console/Make/MigrationRollbackTest/generated_feed_registration_migration_is_reversible.snap
+++ b/tests/.pest/snapshots/Feature/Console/Make/MigrationRollbackTest/generated_feed_registration_migration_is_reversible.snap
@@ -1,0 +1,1 @@
+end of snapshots

--- a/tests/Feature/Console/Make/MigrationRollbackTest.php
+++ b/tests/Feature/Console/Make/MigrationRollbackTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Feeds\FooBarFeed;
+use DragonCode\LaravelFeed\Commands\FeedMakeCommand;
+use DragonCode\LaravelFeed\Models\Feed;
+use DragonCode\LaravelFeed\Queries\FeedQuery;
+use Illuminate\Filesystem\Filesystem;
+use Workbench\App\Feeds\EmptyFeed;
+
+use function Pest\Laravel\artisan;
+
+test('generated feed registration migration is reversible', function () {
+    Feed::query()->forceDelete();
+
+    mockOperations(false);
+
+    artisan(FeedMakeCommand::class, [
+        'name'    => 'FooBar',
+        '--force' => true,
+    ])->assertSuccessful()->run();
+
+    require_once app_path('Feeds/FooBarFeed.php');
+
+    $migrationPath = database_path('migrations');
+    $migrations    = (new Filesystem)->glob($migrationPath . '/*_create_foo_bar_feed.php');
+
+    expect($migrations)->toHaveCount(1);
+
+    app(FeedQuery::class)->create(
+        class: EmptyFeed::class,
+        title: 'Unrelated feed'
+    );
+
+    $options = [
+        '--path'     => $migrationPath,
+        '--realpath' => true,
+    ];
+
+    artisan('migrate', $options)->assertSuccessful()->run();
+
+    expect(Feed::query()->whereClass(FooBarFeed::class)->exists())->toBeTrue()
+        ->and(Feed::query()->whereClass(EmptyFeed::class)->exists())->toBeTrue();
+
+    Feed::query()->whereClass(FooBarFeed::class)->forceDelete();
+
+    artisan('migrate:rollback', $options)->assertSuccessful()->run();
+
+    expect(Feed::withTrashed()->whereClass(FooBarFeed::class)->exists())->toBeFalse()
+        ->and(Feed::query()->whereClass(EmptyFeed::class)->exists())->toBeTrue();
+
+    artisan('migrate', $options)->assertSuccessful()->run();
+
+    expect(Feed::query()->whereClass(FooBarFeed::class)->exists())->toBeTrue()
+        ->and(Feed::query()->whereClass(EmptyFeed::class)->exists())->toBeTrue();
+
+    artisan('migrate:rollback', $options)->assertSuccessful()->run();
+
+    expect(Feed::withTrashed()->whereClass(FooBarFeed::class)->exists())->toBeFalse()
+        ->and(Feed::query()->whereClass(EmptyFeed::class)->exists())->toBeTrue();
+
+    artisan('migrate:rollback', $options)->assertSuccessful()->run();
+
+    expect(Feed::query()->whereClass(EmptyFeed::class)->exists())->toBeTrue();
+});


### PR DESCRIPTION
## Summary

- add class-based removal for feed registrations, including soft-deleted rows
- generate reversible feed registration migrations with a `down(): void` method
- cover migration, rollback, missing-row, unrelated-registration, repeated rollback, and snapshot behavior

## Root cause

Generated feed registration migrations only implemented `up()`. Rolling them back left the database registration behind, which could later reference a feed class removed by the deployment rollback.

## Verification

- related Pest suite: 20 passed, 74 assertions
- full coverage suite: 270 passed, 45 incomplete, 1512 assertions, 95.2% coverage
- type coverage: 100%
- Pint on changed PHP files
- PHP syntax checks and `git diff --check`

The first parallel coverage attempt hit the existing shared lock-directory race from the base branch. The failed test passed in isolation and the full coverage gate passed on rerun; this PR does not modify the implicated filesystem or test cleanup code.

Fixes #198