### PR TITLE
Fail tests when required Pest snapshots are missing

### DIFF
--- a/.ai-factory/patches/2026-07-23-00.15.md
+++ b/.ai-factory/patches/2026-07-23-00.15.md
@@ -1,0 +1,28 @@
+# Pest snapshot names diverged across supported test dependencies
+
+**Date:** 2026-07-23 00:15
+**Files:** phpunit.xml, tests/Expectations.php, tests/Support/Snapshot.php, tests/Unit/Support/SnapshotTest.php, tests/.pest/snapshots/Feature/Feeds/StorageTest/removes_a_pre_registry_remote_primary_file_when_publishing_split_parts.snap
+**Severity:** high
+
+## Problem
+
+The standard test command exited successfully with 45 incomplete tests and created 117 untracked snapshot files. A clean checkout could therefore pass while required assertions were not executed against committed snapshots.
+
+## Root Cause
+
+Pest 3.8.7 builds snapshot names from `dataSetAsStringWithData()`, while Pest 4 builds them from `dataSetAsString()`. The supported dependency matrix therefore resolved the same parameterized test to different snapshot names. Snapshots created from the global `afterEach` hook also appeared after Pest's incomplete post-condition had already run, so `failOnIncomplete` alone could not reject them.
+
+## Solution
+
+Added a test-only snapshot matcher that derives names from test paths and dataset labels, normalizes Windows and Unix separators, and fails immediately when a normal test run creates a snapshot. Snapshot update mode remains available through `--update-snapshots`. Enabled PHPUnit's incomplete-test failure gate and added regression coverage for path normalization, dataset naming, and the strict configuration.
+
+## Prevention
+
+- Keep snapshot identity independent of serialized dataset values.
+- Exercise snapshot helpers with Windows and Unix path inputs.
+- Verify the worktree state before and after the complete test and coverage commands.
+- Test missing snapshots from setup, test bodies, and teardown hooks.
+
+## Tags
+
+`#pest` `#snapshot` `#dataset` `#cross-platform` `#test-gate` `#issue-199`

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,6 +5,7 @@
         bootstrap="vendor/autoload.php"
         cacheResult="false"
         colors="true"
+        failOnIncomplete="true"
 >
     <testsuites>
         <testsuite name="Feature">

--- a/tests/.pest/snapshots/Feature/Feeds/StorageTest/removes_a_pre_registry_remote_primary_file_when_publishing_split_parts.snap
+++ b/tests/.pest/snapshots/Feature/Feeds/StorageTest/removes_a_pre_registry_remote_primary_file_when_publishing_split_parts.snap
@@ -1,0 +1,1 @@
+end of snapshots

--- a/tests/Expectations.php
+++ b/tests/Expectations.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Tests\Support\Snapshot;
+
 expect()->extend('toMatchFileSnapshot', function () {
     $content = readFeedFile($this->value);
 
@@ -44,16 +46,10 @@ expect()->extend('toMatchGeneratedFeed', function () {
 
 expect()->pipe('toMatchSnapshot', function (Closure $next) {
     if (! is_string($this->value)) {
-        return $this->value;
+        return $next();
     }
 
-    $this->value = preg_replace(
-        pattern    : '/(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z)/',
-        replacement: '2025-09-04T04:08:12.000000Z',
-        subject    : $this->value
-    );
-
-    return $next();
+    Snapshot::assertMatches($this->value);
 });
 
 expect()->extend('toBeJsonDocument', function () {

--- a/tests/Support/Snapshot.php
+++ b/tests/Support/Snapshot.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Support;
+
+use Pest\Support\Str;
+use Pest\TestSuite;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class Snapshot
+{
+    private static array $counters = [];
+
+    public static function assertMatches(string $value): void
+    {
+        $suite = TestSuite::getInstance();
+        $test  = $suite->test;
+
+        if (! $test instanceof TestCase) {
+            throw new RuntimeException('Unable to resolve the current test case.');
+        }
+
+        $value = self::normalize($value);
+        $path  = self::path($suite, $test);
+
+        if (! is_file($path)) {
+            self::save($path, $value);
+
+            if (! self::isUpdating()) {
+                Assert::fail(sprintf(
+                    'Snapshot created at [%s].',
+                    self::displayPath($path)
+                ));
+            }
+
+            return;
+        }
+
+        $snapshot = file_get_contents($path);
+
+        if ($snapshot === false) {
+            throw new RuntimeException("Unable to read snapshot file: [$path].");
+        }
+
+        Assert::assertSame(
+            self::normalizeLineEndings($snapshot),
+            self::normalizeLineEndings($value),
+            sprintf(
+                'Failed asserting that the string value matches its snapshot (%s).',
+                self::displayPath($path)
+            )
+        );
+    }
+
+    public static function description(string $testName, string $dataSetName): string
+    {
+        $description = str_replace('__pest_evaluable_', '', $testName);
+        $dataSet     = str_replace('__pest_evaluable_', '', Str::evaluable($dataSetName));
+
+        return str_replace(' ', '_', $description . $dataSet);
+    }
+
+    public static function relativeTestPath(string $filename, string $testsPath): string
+    {
+        $filename  = str_replace('\\', '/', $filename);
+        $testsPath = rtrim(str_replace('\\', '/', $testsPath), '/');
+        $prefix    = $testsPath . '/';
+
+        if (! str_starts_with($filename, $prefix)) {
+            throw new RuntimeException("Test file [$filename] is outside [$testsPath].");
+        }
+
+        $relative = substr($filename, strlen($prefix));
+        $position = strrpos($relative, '.');
+
+        if ($position === false) {
+            throw new RuntimeException("Test file [$filename] has no extension.");
+        }
+
+        return substr($relative, 0, $position);
+    }
+
+    private static function path(TestSuite $suite, TestCase $test): string
+    {
+        $testsPath   = dirname(__DIR__);
+        $relative    = self::relativeTestPath($suite->getFilename(), $testsPath);
+        $description = self::description($test->name(), $test->dataSetAsString());
+        $key         = $suite->getFilename() . '###' . $description;
+        $counter     = (self::$counters[$key] ?? 0) + 1;
+
+        self::$counters[$key] = $counter;
+
+        if ($counter > 1) {
+            $description .= '__' . $counter;
+        }
+
+        return implode(DIRECTORY_SEPARATOR, [
+            $testsPath,
+            '.pest',
+            'snapshots',
+            str_replace('/', DIRECTORY_SEPARATOR, $relative),
+            $description . '.snap',
+        ]);
+    }
+
+    private static function save(string $path, string $value): void
+    {
+        $directory = dirname($path);
+
+        if (! is_dir($directory) && ! mkdir($directory, 0o755, true) && ! is_dir($directory)) {
+            throw new RuntimeException("Unable to create snapshot directory: [$directory].");
+        }
+
+        if (file_put_contents($path, $value) === false) {
+            throw new RuntimeException("Unable to write snapshot file: [$path].");
+        }
+    }
+
+    private static function normalize(string $value): string
+    {
+        $normalized = preg_replace(
+            pattern    : '/(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{6}Z)/',
+            replacement: '2025-09-04T04:08:12.000000Z',
+            subject    : $value
+        );
+
+        if ($normalized === null) {
+            throw new RuntimeException('Unable to normalize snapshot value.');
+        }
+
+        return $normalized;
+    }
+
+    private static function normalizeLineEndings(string $value): string
+    {
+        return strtr($value, ["\r\n" => "\n", "\r" => "\n"]);
+    }
+
+    private static function isUpdating(): bool
+    {
+        return in_array('--update-snapshots', $_SERVER['argv'] ?? [], true);
+    }
+
+    private static function displayPath(string $path): string
+    {
+        $projectPath = dirname(dirname(__DIR__)) . DIRECTORY_SEPARATOR;
+
+        return str_replace('\\', '/', str_replace($projectPath, '', $path));
+    }
+}

--- a/tests/Support/Snapshot.php
+++ b/tests/Support/Snapshot.php
@@ -45,6 +45,12 @@ final class Snapshot
             throw new RuntimeException("Unable to read snapshot file: [$path].");
         }
 
+        if (self::isUpdating()) {
+            self::save($path, $value);
+
+            return;
+        }
+
         Assert::assertSame(
             self::normalizeLineEndings($snapshot),
             self::normalizeLineEndings($value),

--- a/tests/Unit/Support/SnapshotTest.php
+++ b/tests/Unit/Support/SnapshotTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Tests\Support\Snapshot;
+
+test('builds snapshot descriptions from dataset names only', function () {
+    expect(Snapshot::description(
+        '__pest_evaluable_export',
+        ' with data set "dataset "true""'
+    ))->toBe('export_with_data_set__dataset__true__');
+});
+
+test('builds the same snapshot path from windows and unix test paths', function (string $filename, string $testsPath) {
+    expect(Snapshot::relativeTestPath($filename, $testsPath))
+        ->toBe('Feature/Feeds/Defaults/EmptyTest');
+})->with([
+    'windows' => ['C:\\project\\tests\\Feature\\Feeds\\Defaults\\EmptyTest.php', 'C:\\project\\tests'],
+    'unix'    => ['/project/tests/Feature/Feeds/Defaults/EmptyTest.php', '/project/tests'],
+]);
+
+test('fails the test gate for incomplete snapshots', function () {
+    $configuration = new DOMDocument;
+    $configuration->load(dirname(__DIR__, 3) . '/phpunit.xml');
+
+    expect($configuration->documentElement?->getAttribute('failOnIncomplete'))
+        ->toBe('true');
+});

--- a/tests/Unit/Support/SnapshotTest.php
+++ b/tests/Unit/Support/SnapshotTest.php
@@ -26,3 +26,32 @@ test('fails the test gate for incomplete snapshots', function () {
     expect($configuration->documentElement?->getAttribute('failOnIncomplete'))
         ->toBe('true');
 });
+
+test('updates an existing snapshot in update mode', function () {
+    $directory = dirname(__DIR__, 2) . '/.pest/snapshots/Unit/Support/SnapshotTest';
+    $path      = $directory . '/updates_an_existing_snapshot_in_update_mode.snap';
+    $arguments = $_SERVER['argv'] ?? null;
+
+    if (! is_dir($directory)) {
+        mkdir($directory, 0o755, true);
+    }
+
+    file_put_contents($path, 'previous snapshot');
+    $_SERVER['argv'][] = '--update-snapshots';
+
+    try {
+        Snapshot::assertMatches('updated snapshot');
+
+        expect(file_get_contents($path))->toBe('updated snapshot');
+    } finally {
+        if ($arguments === null) {
+            unset($_SERVER['argv']);
+        } else {
+            $_SERVER['argv'] = $arguments;
+        }
+
+        if (is_file($path)) {
+            unlink($path);
+        }
+    }
+});


### PR DESCRIPTION
## Summary

- normalize snapshot paths across supported Pest versions and operating systems
- fail regular test runs when a required snapshot is created
- enable PHPUnit incomplete-test failures and add regression coverage

## Root cause

Pest 3 included serialized dataset values in snapshot names while Pest 4 used dataset labels. Snapshot creation from the global `afterEach` hook also occurred after Pest's incomplete post-condition, allowing the command to exit successfully.

## Validation

- `composer test` — 319 tests, 1633 assertions
- `XDEBUG_MODE=coverage composer test:coverage` — 95.2%
- `composer test:type` — 100%
- `composer validate --strict --no-ansi`
- Pint and PHP syntax checks on changed PHP files
- `git diff --check`

Fixes #199