### PR TITLE
fix(ci): scope documentation deployment secrets

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,11 +9,8 @@ on:
 permissions: {}
 
 env:
-    COMPOSER_TOKEN: ${{ secrets.COMPOSER_TOKEN }}
-    ALGOLIA_APP_NAME: ${{ secrets.ALGOLIA_APPLICATION_ID }}
     ALGOLIA_ARTIFACT: algolia-indexes-LARAVEL-FEEDS.zip
     ALGOLIA_INDEX_NAME: laravel-feeds
-    ALGOLIA_KEY: ${{ secrets.ALGOLIA_KEY }}
     ARTIFACT_DOCS: webHelpLARAVEL-FEEDS2-all.zip
     ARTIFACT_INDEXES: search-indexes
     CONFIG_JSON_PRODUCT: LARAVEL-FEEDS
@@ -167,10 +164,13 @@ jobs:
                 run: unzip -O UTF-8 -qq '${{ env.ALGOLIA_ARTIFACT }}' -d ${{ env.ARTIFACT_INDEXES }}
 
             -   name: Deploy to Algolia
+                env:
+                    ALGOLIA_APP_NAME: ${{ secrets.ALGOLIA_APPLICATION_ID }}
+                    ALGOLIA_KEY: ${{ secrets.ALGOLIA_KEY }}
                 run: |
-                    env algolia-key='${{ env.ALGOLIA_KEY }}' java -jar /opt/builder/help-publication-agent.jar \
+                    env algolia-key="$ALGOLIA_KEY" java -jar /opt/builder/help-publication-agent.jar \
                     update-index \
-                    --application-name '${{ env.ALGOLIA_APP_NAME }}' \
+                    --application-name "$ALGOLIA_APP_NAME" \
                     --index-name '${{ env.ALGOLIA_INDEX_NAME }}' \
                     --product '${{ env.CONFIG_JSON_PRODUCT }}' \
                     --version '${{ env.CONFIG_JSON_VERSION }}' \

--- a/tests/Unit/DocumentationWorkflowTest.php
+++ b/tests/Unit/DocumentationWorkflowTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+test('scopes documentation deployment secrets to the Algolia deployment step', function () {
+    $workflow = file_get_contents(dirname(__DIR__, 2) . '/.github/workflows/docs.yml');
+    $workflow = str_replace("\r\n", "\n", $workflow);
+    $marker   = '            -   name: Deploy to Algolia';
+    $start    = strpos($workflow, $marker);
+
+    expect($start)->not->toBeFalse();
+
+    $step = substr($workflow, $start);
+    $next = strpos($step, "\n            -   ", strlen($marker));
+
+    if ($next !== false) {
+        $step = substr($step, 0, $next);
+    }
+
+    expect($workflow)->not->toContain('COMPOSER_TOKEN');
+
+    foreach (['ALGOLIA_APPLICATION_ID', 'ALGOLIA_KEY'] as $secret) {
+        $expression = '${{ secrets.' . $secret . ' }}';
+
+        expect(substr_count($workflow, $expression))->toBe(1)
+            ->and($step)->toContain($expression);
+    }
+});


### PR DESCRIPTION
## Summary

- scope the Algolia application ID and key to the deployment step
- remove the unused Composer token from the workflow-wide environment
- add regression coverage for documentation secret boundaries

## Root cause

The documentation workflow declared secret-backed variables at workflow scope, so unrelated jobs and third-party action steps inherited credentials they did not consume.

## Impact

Unrelated jobs and action steps no longer receive documentation deployment secrets. Algolia publication reads the same credentials from step-scoped environment variables.

## Testing

- `vendor\bin\pest --colors=never` — 321 tests, 1640 assertions
- `vendor\bin\pint --test tests\Unit\DocumentationWorkflowTest.php`
- local Symfony YAML parse of `.github/workflows/docs.yml`
- `git diff --cached --check`

Fixes #200