### PR TITLE
fix(ci): pin Writerside publisher image by digest

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -152,7 +152,7 @@ jobs:
         timeout-minutes: 3
 
         container:
-            image: registry.jetbrains.team/p/writerside/builder/algolia-publisher:2.0.32-3
+            image: registry.jetbrains.team/p/writerside/builder/algolia-publisher:2.0.32-3@sha256:fae5a7ab5f11f23b5c08014e507d11149a4e6844c7e3acd1957671428709ae9b
 
         steps:
             -   name: Download search artifact

--- a/tests/Unit/DocumentationWorkflowTest.php
+++ b/tests/Unit/DocumentationWorkflowTest.php
@@ -2,6 +2,16 @@
 
 declare(strict_types=1);
 
+test('pins the Writerside Algolia publisher image to a reviewed digest', function () {
+    $workflow = file_get_contents(dirname(__DIR__, 2) . '/.github/workflows/docs.yml');
+    $workflow = str_replace("\r\n", "\n", $workflow);
+    $tag      = 'registry.jetbrains.team/p/writerside/builder/algolia-publisher:2.0.32-3';
+    $image    = $tag . '@sha256:fae5a7ab5f11f23b5c08014e507d11149a4e6844c7e3acd1957671428709ae9b';
+
+    expect(substr_count($workflow, $image))->toBe(1)
+        ->and($workflow)->not->toContain("            image: $tag\n");
+});
+
 test('scopes documentation deployment secrets to the Algolia deployment step', function () {
     $workflow = file_get_contents(dirname(__DIR__, 2) . '/.github/workflows/docs.yml');
     $workflow = str_replace("\r\n", "\n", $workflow);


### PR DESCRIPTION
## Summary

- pin the Writerside Algolia publisher image to its reviewed SHA-256 digest
- retain the human-readable `2.0.32-3` tag in the image reference
- add regression coverage that requires the exact tag and digest

## Root cause

The documentation workflow referenced the publisher image by a mutable tag, so the same workflow revision could execute different container bytes if the registry tag moved.

## Validation

- `composer test` — 322 tests passed, 1642 assertions
- `vendor/bin/pint --test tests/Unit/DocumentationWorkflowTest.php`
- `composer validate --strict --no-check-publish`
- parsed `.github/workflows/docs.yml` with Symfony YAML
- verified the tag digest and pinned manifest in JetBrains Registry
- `git diff --check`

Closes #201