### PR TITLE
Support optional values in feed output

### DIFF
--- a/.ai-factory/patches/2026-07-25-18.46.md
+++ b/.ai-factory/patches/2026-07-25-18.46.md
@@ -1,0 +1,28 @@
+# Optional filtering changed empty JSON objects into arrays
+
+**Date:** 2026-07-25 18:46
+**Files:** src/Converters/JsonConverter.php, src/Converters/JsonLinesConverter.php, tests/Unit/Converters/OptionalValuesTest.php
+**Severity:** medium
+
+## Problem
+
+Associative JSON containers containing only optional values were serialized as arrays after those values were removed. Nested maps and all-optional feed items produced `[]` instead of `{}` in JSON and JSON Lines output.
+
+## Root Cause
+
+PHP represents both an empty map and an empty list as `[]`. The converters recorded the original container shape before filtering but returned the same empty array for both shapes, so `json_encode()` could no longer distinguish them.
+
+## Solution
+
+The converters now normalize each array through a shape-aware internal path. An originally associative container that becomes empty is represented by `stdClass`, while lists are still reindexed and remain arrays. Existing protected converter method signatures remain unchanged for subclass compatibility.
+
+## Prevention
+
+- Preserve structural type before removing serialization markers.
+- Test decoded JSON without associative mode when object and array shapes must remain distinct.
+- Cover top-level maps, nested maps, and lists in both JSON formats.
+- Do not use `JSON_FORCE_OBJECT` for mixed object and list trees.
+
+## Tags
+
+`#json` `#json-lines` `#optional-values` `#serialization` `#backward-compatibility` `#regression`

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "pestphp/pest": "^3.8.7 || ^4.0",
         "pestphp/pest-plugin-laravel": "^3.2 || ^4.0",
         "pestphp/pest-plugin-type-coverage": "^3.6.1 || ^4.0",
+        "spatie/laravel-data": "^4.23",
         "symfony/var-dumper": "^7.3 || ^8.0"
     },
     "minimum-stability": "stable",

--- a/docs/snippets/optional-values.php
+++ b/docs/snippets/optional-values.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Feeds\Items;
+
+use DragonCode\LaravelFeed\Data\OptionalData;
+use DragonCode\LaravelFeed\Feeds\Items\FeedItem;
+
+class UserFeedItem extends FeedItem
+{
+    public function toArray(): array
+    {
+        return [
+            'id'   => $this->model->id,
+            'name' => $this->model->name,
+
+            'cityId' => $this->model->city?->id ?? new OptionalData,
+
+            'createdAt' => $this->model->created_at,
+            'updatedAt' => $this->model->updated_at ?? new OptionalData,
+        ];
+    }
+}

--- a/docs/topics/create-feeds.topic
+++ b/docs/topics/create-feeds.topic
@@ -96,6 +96,35 @@
                 </p>
 
                 <code-block lang="php" src="generation-feed-item.php" include-lines="5-" />
+
+                <chapter title="Optional values" id="optional_values">
+                    <p>
+                        To omit a field when its value is unavailable, return an instance of
+                        <code>DragonCode\LaravelFeed\Data\OptionalData</code> as its value:
+                    </p>
+
+                    <code-block lang="php" src="optional-values.php" include-lines="5-" />
+
+                    <p>
+                        Optional fields are removed from JSON and JSON Lines objects and from XML and RSS elements,
+                        including regular nested fields. CSV keeps the column position and writes an empty field.
+                    </p>
+
+                    <p>
+                        If your application uses
+                        <a href="https://spatie.be/docs/laravel-data/v4/as-a-data-transfer-object/optional-properties">
+                            Spatie Laravel Data
+                        </a>, you can return
+                        <code>Spatie\LaravelData\Optional</code> instead. Both optional value classes are handled
+                        automatically.
+                    </p>
+
+                    <code-block lang="php">
+                        use Spatie\LaravelData\Optional;
+
+                        'updatedAt' => $this->model->updated_at ?? Optional::create(),
+                    </code-block>
+                </chapter>
             </chapter>
         </chapter>
     </chapter>

--- a/src/Concerns/InteractsWithOptional.php
+++ b/src/Concerns/InteractsWithOptional.php
@@ -17,10 +17,6 @@ trait InteractsWithOptional
             return true;
         }
 
-        if (class_exists(Optional::class) && $value instanceof Optional) {
-            return true;
-        }
-
-        return false;
+        return class_exists(Optional::class) && $value instanceof Optional;
     }
 }

--- a/src/Concerns/InteractsWithOptional.php
+++ b/src/Concerns/InteractsWithOptional.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DragonCode\LaravelFeed\Concerns;
+
+use DragonCode\LaravelFeed\Data\OptionalData;
+use Spatie\LaravelData\Optional;
+
+use function class_exists;
+
+trait InteractsWithOptional
+{
+    protected function isOptional(mixed $value): bool
+    {
+        if ($value instanceof OptionalData) {
+            return true;
+        }
+
+        if (class_exists(Optional::class) && $value instanceof Optional) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Converters/Converter.php
+++ b/src/Converters/Converter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DragonCode\LaravelFeed\Converters;
 
 use Closure;
+use DragonCode\LaravelFeed\Concerns\InteractsWithOptional;
 use DragonCode\LaravelFeed\Feeds\Feed;
 use DragonCode\LaravelFeed\Feeds\Items\FeedItem;
 use DragonCode\LaravelFeed\Services\TransformerService;
@@ -12,25 +13,27 @@ use Illuminate\Container\Attributes\Config;
 
 abstract class Converter
 {
+    use InteractsWithOptional;
+
     protected array $transformers = [];
 
     protected ?Closure $transformerPipeline = null;
+
+    abstract public function footer(Feed $feed): string;
+
+    abstract public function header(Feed $feed): string;
+
+    abstract public function info(array $info, bool $afterRoot): string;
+
+    abstract public function item(FeedItem $item, bool $isLast): string;
+
+    abstract public function root(Feed $feed): string;
 
     public function __construct(
         #[Config('feeds.pretty')]
         protected bool $pretty,
         protected readonly TransformerService $transformer,
     ) {}
-
-    abstract public function header(Feed $feed): string;
-
-    abstract public function footer(Feed $feed): string;
-
-    abstract public function root(Feed $feed): string;
-
-    abstract public function item(FeedItem $item, bool $isLast): string;
-
-    abstract public function info(array $info, bool $afterRoot): string;
 
     public function lineEnding(): string
     {

--- a/src/Converters/CsvConverter.php
+++ b/src/Converters/CsvConverter.php
@@ -85,6 +85,10 @@ class CsvConverter extends Converter
     protected function transform(array $data): array
     {
         foreach ($data as $column => &$value) {
+            if ($this->isOptional($value)) {
+                continue;
+            }
+
             if (is_array($value)) {
                 throw new InvalidCsvValueException($column);
             }
@@ -121,7 +125,8 @@ class CsvConverter extends Converter
             }
 
             return $content;
-        } finally {
+        }
+        finally {
             fclose($stream);
         }
     }

--- a/src/Converters/CsvConverter.php
+++ b/src/Converters/CsvConverter.php
@@ -86,6 +86,8 @@ class CsvConverter extends Converter
     {
         foreach ($data as $column => &$value) {
             if ($this->isOptional($value)) {
+                $value = '';
+
                 continue;
             }
 
@@ -125,8 +127,7 @@ class CsvConverter extends Converter
             }
 
             return $content;
-        }
-        finally {
+        } finally {
             fclose($stream);
         }
     }

--- a/src/Converters/JsonConverter.php
+++ b/src/Converters/JsonConverter.php
@@ -79,7 +79,8 @@ class JsonConverter extends Converter implements FileAwareInfoConverter
 
         try {
             return $this->info($info, $afterRoot);
-        } finally {
+        }
+        finally {
             $this->fileHasItems = $previous;
         }
     }
@@ -87,6 +88,10 @@ class JsonConverter extends Converter implements FileAwareInfoConverter
     protected function performItem(array $data): array
     {
         foreach ($data as &$value) {
+            if ($this->isOptional($value)) {
+                continue;
+            }
+
             if (is_array($value)) {
                 $value = $this->performItem($value);
 

--- a/src/Converters/JsonConverter.php
+++ b/src/Converters/JsonConverter.php
@@ -63,6 +63,10 @@ class JsonConverter extends Converter implements FileAwareInfoConverter
     {
         $data = $this->performValue($info);
 
+        if ($data instanceof stdClass) {
+            return '';
+        }
+
         $json = $this->encodeValue($data);
 
         if (! $afterRoot) {

--- a/src/Converters/JsonConverter.php
+++ b/src/Converters/JsonConverter.php
@@ -10,6 +10,8 @@ use DragonCode\LaravelFeed\Feeds\Items\FeedItem;
 use DragonCode\LaravelFeed\Services\TransformerService;
 use Illuminate\Container\Attributes\Config;
 
+use function array_is_list;
+use function array_values;
 use function is_array;
 use function json_encode;
 use function mb_substr;
@@ -79,16 +81,19 @@ class JsonConverter extends Converter implements FileAwareInfoConverter
 
         try {
             return $this->info($info, $afterRoot);
-        }
-        finally {
+        } finally {
             $this->fileHasItems = $previous;
         }
     }
 
     protected function performItem(array $data): array
     {
-        foreach ($data as &$value) {
+        $isList = array_is_list($data);
+
+        foreach ($data as $key => &$value) {
             if ($this->isOptional($value)) {
+                unset($data[$key]);
+
                 continue;
             }
 
@@ -101,7 +106,9 @@ class JsonConverter extends Converter implements FileAwareInfoConverter
             $value = $this->transformValue($value);
         }
 
-        return $data;
+        unset($value);
+
+        return $isList ? array_values($data) : $data;
     }
 
     protected function encode(array $data): string

--- a/src/Converters/JsonConverter.php
+++ b/src/Converters/JsonConverter.php
@@ -9,6 +9,7 @@ use DragonCode\LaravelFeed\Feeds\Feed;
 use DragonCode\LaravelFeed\Feeds\Items\FeedItem;
 use DragonCode\LaravelFeed\Services\TransformerService;
 use Illuminate\Container\Attributes\Config;
+use stdClass;
 
 use function array_is_list;
 use function array_values;
@@ -51,18 +52,18 @@ class JsonConverter extends Converter implements FileAwareInfoConverter
 
     public function item(FeedItem $item, bool $isLast): string
     {
-        $data = $this->performItem($item->toArray());
+        $data = $this->performValue($item->toArray());
 
         $suffix = $isLast ? '' : ',';
 
-        return $this->encode($data) . $suffix;
+        return $this->encodeValue($data) . $suffix;
     }
 
     public function info(array $info, bool $afterRoot): string
     {
-        $data = $this->performItem($info);
+        $data = $this->performValue($info);
 
-        $json = $this->encode($data);
+        $json = $this->encodeValue($data);
 
         if (! $afterRoot) {
             $json = mb_substr($json, 1, -1);
@@ -98,7 +99,7 @@ class JsonConverter extends Converter implements FileAwareInfoConverter
             }
 
             if (is_array($value)) {
-                $value = $this->performItem($value);
+                $value = $this->performValue($value);
 
                 continue;
             }
@@ -109,6 +110,23 @@ class JsonConverter extends Converter implements FileAwareInfoConverter
         unset($value);
 
         return $isList ? array_values($data) : $data;
+    }
+
+    private function encodeValue(array|stdClass $data): string
+    {
+        if ($data instanceof stdClass) {
+            return json_encode($data, $this->jsonOptions());
+        }
+
+        return $this->encode($data);
+    }
+
+    private function performValue(array $data): array|stdClass
+    {
+        $isList = array_is_list($data);
+        $data   = $this->performItem($data);
+
+        return ! $isList && $data === [] ? new stdClass : $data;
     }
 
     protected function encode(array $data): string

--- a/src/Converters/JsonLinesConverter.php
+++ b/src/Converters/JsonLinesConverter.php
@@ -56,6 +56,10 @@ class JsonLinesConverter extends Converter
     protected function performItem(array $data): array
     {
         foreach ($data as &$value) {
+            if ($this->isOptional($value)) {
+                continue;
+            }
+
             if (is_array($value)) {
                 $value = $this->performItem($value);
 

--- a/src/Converters/JsonLinesConverter.php
+++ b/src/Converters/JsonLinesConverter.php
@@ -8,6 +8,7 @@ use DragonCode\LaravelFeed\Feeds\Feed;
 use DragonCode\LaravelFeed\Feeds\Items\FeedItem;
 use DragonCode\LaravelFeed\Services\TransformerService;
 use Illuminate\Container\Attributes\Config;
+use stdClass;
 
 use function array_is_list;
 use function array_values;
@@ -43,16 +44,16 @@ class JsonLinesConverter extends Converter
 
     public function item(FeedItem $item, bool $isLast): string
     {
-        $data = $this->performItem($item->toArray());
+        $data = $this->performValue($item->toArray());
 
-        return $this->encode($data);
+        return $this->encodeValue($data);
     }
 
     public function info(array $info, bool $afterRoot): string
     {
-        $data = $this->performItem($info);
+        $data = $this->performValue($info);
 
-        return $this->encode($data);
+        return $this->encodeValue($data);
     }
 
     protected function performItem(array $data): array
@@ -67,7 +68,7 @@ class JsonLinesConverter extends Converter
             }
 
             if (is_array($value)) {
-                $value = $this->performItem($value);
+                $value = $this->performValue($value);
 
                 continue;
             }
@@ -78,6 +79,23 @@ class JsonLinesConverter extends Converter
         unset($value);
 
         return $isList ? array_values($data) : $data;
+    }
+
+    private function encodeValue(array|stdClass $data): string
+    {
+        if ($data instanceof stdClass) {
+            return json_encode($data, $this->options);
+        }
+
+        return $this->encode($data);
+    }
+
+    private function performValue(array $data): array|stdClass
+    {
+        $isList = array_is_list($data);
+        $data   = $this->performItem($data);
+
+        return ! $isList && $data === [] ? new stdClass : $data;
     }
 
     protected function encode(array $data): string

--- a/src/Converters/JsonLinesConverter.php
+++ b/src/Converters/JsonLinesConverter.php
@@ -9,6 +9,8 @@ use DragonCode\LaravelFeed\Feeds\Items\FeedItem;
 use DragonCode\LaravelFeed\Services\TransformerService;
 use Illuminate\Container\Attributes\Config;
 
+use function array_is_list;
+use function array_values;
 use function is_array;
 use function json_encode;
 
@@ -55,8 +57,12 @@ class JsonLinesConverter extends Converter
 
     protected function performItem(array $data): array
     {
-        foreach ($data as &$value) {
+        $isList = array_is_list($data);
+
+        foreach ($data as $key => &$value) {
             if ($this->isOptional($value)) {
+                unset($data[$key]);
+
                 continue;
             }
 
@@ -69,7 +75,9 @@ class JsonLinesConverter extends Converter
             $value = $this->transformValue($value);
         }
 
-        return $data;
+        unset($value);
+
+        return $isList ? array_values($data) : $data;
     }
 
     protected function encode(array $data): string

--- a/src/Converters/XmlConverter.php
+++ b/src/Converters/XmlConverter.php
@@ -202,8 +202,7 @@ class XmlConverter extends Converter
             $reason   = isset($errors[0]) ? trim($errors[0]->message) : null;
         } catch (Throwable $exception) {
             throw new InvalidXmlFragmentException(previous: $exception);
-        }
-        finally {
+        } finally {
             if (! $internalErrors) {
                 libxml_clear_errors();
             }

--- a/src/Converters/XmlConverter.php
+++ b/src/Converters/XmlConverter.php
@@ -118,6 +118,10 @@ class XmlConverter extends Converter
         foreach ($items as $key => $value) {
             $key = $this->convertKey($key);
 
+            if ($this->isOptional($value)) {
+                continue;
+            }
+
             match (true) {
                 $this->isAttributes($key) => $this->setAttributes($parent, $value),
                 $this->isCData($key)      => $this->setCData($parent, $value),
@@ -198,7 +202,8 @@ class XmlConverter extends Converter
             $reason   = isset($errors[0]) ? trim($errors[0]->message) : null;
         } catch (Throwable $exception) {
             throw new InvalidXmlFragmentException(previous: $exception);
-        } finally {
+        }
+        finally {
             if (! $internalErrors) {
                 libxml_clear_errors();
             }

--- a/src/Data/OptionalData.php
+++ b/src/Data/OptionalData.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DragonCode\LaravelFeed\Data;
+
+final readonly class OptionalData {}

--- a/tests/Feature/Feeds/Formats/Json/InfoSeparatorTest.php
+++ b/tests/Feature/Feeds/Formats/Json/InfoSeparatorTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use DragonCode\LaravelFeed\Data\ElementData;
+use DragonCode\LaravelFeed\Data\OptionalData;
+use DragonCode\LaravelFeed\Feeds\Info\FeedInfo;
 use DragonCode\LaravelFeed\Services\GeneratorService;
 use Workbench\App\Data\NewsFakeData;
 use Workbench\App\Feeds\JsonInfoFeed;
@@ -22,18 +24,40 @@ final class JsonRootBeforeInfoFeed extends JsonInfoFeed
     }
 }
 
+final class JsonOptionalInfoFeed extends JsonRootInfoFeed
+{
+    public function info(): FeedInfo
+    {
+        return new class extends FeedInfo {
+            public function toArray(): array
+            {
+                return [
+                    'optional' => new OptionalData,
+                ];
+            }
+        };
+    }
+
+    public function filename(): string
+    {
+        return 'json-optional-info.json';
+    }
+}
+
 test('keeps info separators valid', function () {
     $cases = [
-        'rootless empty feed'         => [JsonInfoFeed::class, false, '0.name'],
-        'root before info empty feed' => [JsonRootBeforeInfoFeed::class, false, 'items.0.name'],
-        'info before root empty feed' => [JsonRootInfoFeed::class, false, 'name'],
-        'root before info with items' => [JsonRootBeforeInfoFeed::class, true, 'items.0.name'],
+        'rootless empty feed'                   => [JsonInfoFeed::class, false, '0.name', 'Laravel', null],
+        'root before info empty feed'           => [JsonRootBeforeInfoFeed::class, false, 'items.0.name', 'Laravel', null],
+        'info before root empty feed'           => [JsonRootInfoFeed::class, false, 'name', 'Laravel', null],
+        'root before info with items'           => [JsonRootBeforeInfoFeed::class, true, 'items.0.name', 'Laravel', 'items.1.title'],
+        'fully optional info before root'       => [JsonOptionalInfoFeed::class, false, 'optional', null, null],
+        'fully optional info before root items' => [JsonOptionalInfoFeed::class, true, 'optional', null, 'items.0.title'],
     ];
 
     foreach ([false, true] as $pretty) {
         setPrettyXml($pretty);
 
-        foreach ($cases as $case => [$class, $withItems, $infoPath]) {
+        foreach ($cases as $case => [$class, $withItems, $infoPath, $expected, $itemPath]) {
             News::query()->delete();
 
             if ($withItems) {
@@ -60,10 +84,16 @@ test('keeps info separators valid', function () {
             expect($document)
                 ->toBeArray()
                 ->and(data_get($document, $infoPath))
-                ->toBe('Laravel');
+                ->toBe($expected);
 
-            if ($withItems) {
-                expect(data_get($document, 'items.1.title'))->toBe('Some 1');
+            if ($itemPath !== null) {
+                expect(data_get($document, $itemPath))->toBe('Some 1');
+            }
+
+            if ($class === JsonOptionalInfoFeed::class) {
+                expect($document)
+                    ->toHaveKey('items')
+                    ->not->toHaveKey('optional');
             }
         }
     }

--- a/tests/Unit/Converters/OptionalValuesTest.php
+++ b/tests/Unit/Converters/OptionalValuesTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+use DragonCode\LaravelFeed\Converters\CsvConverter;
+use DragonCode\LaravelFeed\Converters\JsonConverter;
+use DragonCode\LaravelFeed\Converters\JsonLinesConverter;
+use DragonCode\LaravelFeed\Converters\RssConverter;
+use DragonCode\LaravelFeed\Converters\XmlConverter;
+use DragonCode\LaravelFeed\Data\OptionalData;
+use DragonCode\LaravelFeed\Feeds\Items\FeedItem;
+use Spatie\LaravelData\Optional;
+
+test('omits optional values from JSON formats', function (string $converter, object $optional) {
+    $item = mock(FeedItem::class);
+    $item->shouldReceive('toArray')->once()->andReturn([
+        'id'       => 123,
+        'optional' => $optional,
+        'meta'     => [
+            'name'     => 'Laravel Feeds',
+            'optional' => $optional,
+        ],
+        'tags' => [
+            'laravel',
+            $optional,
+            'feeds',
+        ],
+    ]);
+
+    $content = app($converter)->item($item, true);
+    $actual  = $converter === JsonConverter::class
+        ? parseJsonDocument($content)
+        : parseJsonLines($content)[0];
+
+    expect($actual)->toBe([
+        'id'   => 123,
+        'meta' => [
+            'name' => 'Laravel Feeds',
+        ],
+        'tags' => [
+            'laravel',
+            'feeds',
+        ],
+    ]);
+})->with([
+    JsonConverter::class,
+    JsonLinesConverter::class,
+])->with([
+    'Laravel Feeds optional'       => new OptionalData,
+    'Spatie Laravel Data optional' => Optional::create(),
+]);
+
+test('omits optional values from XML formats', function (string $converter, object $optional) {
+    $item = mock(FeedItem::class);
+    $item->shouldReceive('name')->andReturn('item');
+    $item->shouldReceive('attributes')->once()->andReturn([]);
+    $item->shouldReceive('toArray')->once()->andReturn([
+        'id'       => 123,
+        'optional' => $optional,
+        'meta'     => [
+            'name'     => 'Laravel Feeds',
+            'optional' => $optional,
+        ],
+    ]);
+
+    $document = parseXmlDocument(
+        app($converter)->item($item, true)
+    );
+
+    expect($document->getElementsByTagName('optional')->length)
+        ->toBe(0)
+        ->and($document->getElementsByTagName('id')->item(0)?->textContent)
+        ->toBe('123')
+        ->and($document->getElementsByTagName('name')->item(0)?->textContent)
+        ->toBe('Laravel Feeds');
+})->with([
+    XmlConverter::class,
+    RssConverter::class,
+])->with([
+    'Laravel Feeds optional'       => new OptionalData,
+    'Spatie Laravel Data optional' => Optional::create(),
+]);
+
+test('writes optional values as empty CSV fields', function (object $optional) {
+    $item = mock(FeedItem::class);
+    $item->shouldReceive('toArray')->once()->andReturn([
+        'id'       => 123,
+        'optional' => $optional,
+        'name'     => 'Laravel Feeds',
+    ]);
+
+    $content = app(CsvConverter::class)->item($item, true);
+
+    expect(parseCsv($content))->toBe([[
+        '123',
+        '',
+        'Laravel Feeds',
+    ]]);
+})->with([
+    'Laravel Feeds optional'       => new OptionalData,
+    'Spatie Laravel Data optional' => Optional::create(),
+]);

--- a/tests/Unit/Converters/OptionalValuesTest.php
+++ b/tests/Unit/Converters/OptionalValuesTest.php
@@ -50,6 +50,42 @@ test('omits optional values from JSON formats', function (string $converter, obj
     'Spatie Laravel Data optional' => Optional::create(),
 ]);
 
+test('preserves JSON container shapes after omitting optional values', function (string $converter, object $optional) {
+    $nestedItem = mock(FeedItem::class);
+    $nestedItem->shouldReceive('toArray')->once()->andReturn([
+        'object' => [
+            'optional' => $optional,
+        ],
+        'list' => [
+            $optional,
+        ],
+    ]);
+
+    $emptyItem = mock(FeedItem::class);
+    $emptyItem->shouldReceive('toArray')->once()->andReturn([
+        'optional' => $optional,
+    ]);
+
+    $instance   = app($converter);
+    $nestedData = json_decode($instance->item($nestedItem, true), flags: JSON_THROW_ON_ERROR);
+    $emptyData  = json_decode($instance->item($emptyItem, true), flags: JSON_THROW_ON_ERROR);
+
+    expect($nestedData)
+        ->toBeInstanceOf(stdClass::class)
+        ->and($nestedData->object)
+        ->toBeInstanceOf(stdClass::class)
+        ->and($nestedData->list)
+        ->toBe([])
+        ->and($emptyData)
+        ->toBeInstanceOf(stdClass::class);
+})->with([
+    JsonConverter::class,
+    JsonLinesConverter::class,
+])->with([
+    'Laravel Feeds optional'       => new OptionalData,
+    'Spatie Laravel Data optional' => Optional::create(),
+]);
+
 test('omits optional values from XML formats', function (string $converter, object $optional) {
     $item = mock(FeedItem::class);
     $item->shouldReceive('name')->andReturn('item');


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

- Add `OptionalData` as a marker for unavailable feed fields.
- Omit optional values from JSON, JSON Lines, XML, and RSS output, including nested fields and list entries.
- Serialize optional CSV values as empty fields to preserve column positions.
- Support `Spatie\LaravelData\Optional` when Laravel Data is installed.
- Document optional values and cover both marker types in converter tests.