### PR TITLE
fix(xml): omit OptionalData/Spatie Optional from XML attributes and repeated elements

### DIFF
--- a/.ai-factory/patches/2026-07-25-23.27.md
+++ b/.ai-factory/patches/2026-07-25-23.27.md
@@ -1,0 +1,27 @@
+# Optional XML values in attributes and repeated elements
+
+**Date:** 2026-07-25 23:27
+**Files:** src/Converters/XmlConverter.php, tests/Unit/Converters/OptionalValuesTest.php
+**Severity:** medium
+
+## Problem
+
+XML and RSS already omitted optional values from ordinary elements, but an `OptionalData` or Spatie `Optional` used as an item/root attribute, a nested `@attributes` value, or an entry in a repeated `@element` directive still reached scalar transformation and could fail or produce an unwanted node.
+
+## Root Cause
+
+The general XML item traversal checked optional values, while the specialized attribute and repeated-element serialization paths bypassed that traversal and did not repeat the omission guard.
+
+## Solution
+
+Skip optional attribute values in `setAttributes()` and return before creating a node for an optional value in `setItems()`. Added regression coverage for item attributes, nested attributes, and repeated XML/RSS elements for both supported optional marker classes.
+
+## Prevention
+
+- Apply optional-value omission at every XML serialization boundary, including directive-specific paths.
+- Cover both ordinary nested data and XML-only structures when adding sentinel values.
+- Keep CSV behavior separate because its fixed column schema requires empty placeholders instead of omitted fields.
+
+## Tags
+
+`#optional-value` `#xml` `#rss` `#serialization`

--- a/src/Converters/XmlConverter.php
+++ b/src/Converters/XmlConverter.php
@@ -170,6 +170,10 @@ class XmlConverter extends Converter
     protected function setAttributes(DOMNode $element, array $attributes): void
     {
         foreach ($attributes as $key => $value) {
+            if ($this->isOptional($value)) {
+                continue;
+            }
+
             $element->setAttribute($key, (string) $this->transformValue($value));
         }
     }
@@ -228,6 +232,10 @@ class XmlConverter extends Converter
 
     protected function setItems(DOMNode $parent, string $key, mixed $value): void
     {
+        if ($this->isOptional($value)) {
+            return;
+        }
+
         $element = $this->createElement($key, is_array($value) ? '' : $value);
 
         if (is_array($value)) {

--- a/tests/Unit/Converters/OptionalValuesTest.php
+++ b/tests/Unit/Converters/OptionalValuesTest.php
@@ -117,6 +117,57 @@ test('omits optional values from XML formats', function (string $converter, obje
     'Spatie Laravel Data optional' => Optional::create(),
 ]);
 
+test('omits optional values from XML attributes and repeated elements', function (string $converter, object $optional) {
+    $item = mock(FeedItem::class);
+    $item->shouldReceive('name')->andReturn('item');
+    $item->shouldReceive('attributes')->once()->andReturn([
+        'id'       => 123,
+        'optional' => $optional,
+    ]);
+    $item->shouldReceive('toArray')->once()->andReturn([
+        'meta' => [
+            '@attributes' => [
+                'name'     => 'Laravel Feeds',
+                'optional' => $optional,
+            ],
+        ],
+        '@tag' => [
+            'laravel',
+            $optional,
+            'feeds',
+        ],
+    ]);
+
+    $document = parseXmlDocument(
+        app($converter)->item($item, true)
+    );
+
+    $root = $document->documentElement;
+    $meta = $document->getElementsByTagName('meta')->item(0);
+    $tags = $document->getElementsByTagName('tag');
+
+    expect($root?->getAttribute('id'))
+        ->toBe('123')
+        ->and($root?->hasAttribute('optional'))
+        ->toBeFalse()
+        ->and($meta?->getAttribute('name'))
+        ->toBe('Laravel Feeds')
+        ->and($meta?->hasAttribute('optional'))
+        ->toBeFalse()
+        ->and($tags->length)
+        ->toBe(2)
+        ->and($tags->item(0)?->textContent)
+        ->toBe('laravel')
+        ->and($tags->item(1)?->textContent)
+        ->toBe('feeds');
+})->with([
+    XmlConverter::class,
+    RssConverter::class,
+])->with([
+    'Laravel Feeds optional'       => new OptionalData,
+    'Spatie Laravel Data optional' => Optional::create(),
+]);
+
 test('writes optional values as empty CSV fields', function (object $optional) {
     $item = mock(FeedItem::class);
     $item->shouldReceive('toArray')->once()->andReturn([


### PR DESCRIPTION
### Motivation

- Ensure `OptionalData` (and `Spatie\LaravelData\Optional`) values are completely hidden from serialized outputs where omission is desired, including XML/RSS attributes and directive-driven repeated elements.  

### Description

- Skip optional marker values when serializing XML attributes by adding a guard in `setAttributes()` in `src/Converters/XmlConverter.php`.  
- Avoid creating nodes for optional entries in repeated XML directive paths by returning early in `setItems()` in `src/Converters/XmlConverter.php`.  
- Add a regression test `omits optional values from XML attributes and repeated elements` to `tests/Unit/Converters/OptionalValuesTest.php` covering element attributes, nested `@attributes`, and repeated `@element` values for both `OptionalData` and Spatie `Optional`.  
- Record the rationale and prevention notes in a patch file under `.ai-factory/patches/` to capture the root cause and solution for future reference.  

### Testing

- `php -l src/Converters/XmlConverter.php` and `php -l tests/Unit/Converters/OptionalValuesTest.php` passed with no syntax errors.  
- `git diff --check` / `git diff --cached --check` returned clean results for the staged changes.  
- Attempted to run the unit test via `vendor/bin/pest tests/Unit/Converters/OptionalValuesTest.php --filter='omits optional values from XML attributes and repeated elements'` but `vendor/bin/pest` was not available because dependencies are not installed.  
- `composer install` could not complete due to network/Packagist access being blocked in the environment (`CONNECT tunnel failed, response 403`), so full test execution (Pest) could not be performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a654607b37c83248ec0ab3a3dee8580)