### PR TITLE
Add queue support for feed generation

### DIFF
--- a/config/feeds.php
+++ b/config/feeds.php
@@ -75,6 +75,18 @@ return [
         'background' => (bool) env('FEED_SCHEDULE_RUN_BACKGROUND', true),
     ],
 
+    'queue' => [
+        'enabled' => (bool) env('FEED_QUEUE_ENABLED', false),
+
+        'connection' => env('FEED_QUEUE_CONNECTION', env('QUEUE_CONNECTION', 'database')),
+
+        'name' => env('FEED_QUEUE_NAME'),
+
+        'group' => env('FEED_QUEUE_GROUP'),
+
+        'unique_ttl' => (int) env('FEED_QUEUE_UNIQUE_TTL', 3600),
+    ],
+
     /**
      * --------------------------------------------------------------------------
      * Console display options

--- a/config/feeds.php
+++ b/config/feeds.php
@@ -75,15 +75,31 @@ return [
         'background' => (bool) env('FEED_SCHEDULE_RUN_BACKGROUND', true),
     ],
 
+    /**
+     * --------------------------------------------------------------------------
+     * Queue options for feed generation
+     * --------------------------------------------------------------------------
+     *
+     * Queue mode lets the console command dispatch feed generation jobs instead
+     * of building feeds in the command process. It is disabled by default.
+     */
     'queue' => [
+        /** Dispatch feed generation jobs to Laravel Queue. */
         'enabled' => (bool) env('FEED_QUEUE_ENABLED', false),
 
+        /**
+         * The queue connection used for feed jobs.
+         * Falls back to QUEUE_CONNECTION and then to the database connection.
+         */
         'connection' => env('FEED_QUEUE_CONNECTION', env('QUEUE_CONNECTION', 'database')),
 
+        /**
+         * The queue name used for feed jobs.
+         * A null value uses the connection's default queue.
+         */
         'name' => env('FEED_QUEUE_NAME'),
 
-        'group' => env('FEED_QUEUE_GROUP'),
-
+        /** Maximum lifetime of a feed job's uniqueness lock, in seconds. */
         'unique_ttl' => (int) env('FEED_QUEUE_UNIQUE_TTL', 3600),
     ],
 

--- a/docs/topics/generation.topic
+++ b/docs/topics/generation.topic
@@ -56,6 +56,49 @@
         </code-block>
     </chapter>
 
+    <chapter title="Queue" id="queue">
+        <p>
+            Feed generation runs in the console process by default. For feeds that take a long time or use a large
+            amount of memory, enable Laravel Queue mode in your environment:
+        </p>
+
+        <code-block lang="bash">
+            FEED_QUEUE_ENABLED=true
+            FEED_QUEUE_CONNECTION=redis
+            FEED_QUEUE_NAME=feeds
+            FEED_QUEUE_UNIQUE_TTL=3600
+        </code-block>
+
+        <p>
+            When queue mode is enabled, <code>%command-generate-short%</code> dispatches one job for every active feed
+            instead of generating the files directly. With an asynchronous connection, the command returns after the
+            jobs have been dispatched. Start a
+            <a href="https://laravel.com/docs/queues#running-the-queue-worker">queue worker</a>
+            for the selected connection and queue to process those jobs.
+        </p>
+
+        <list>
+            <li>
+                <code>FEED_QUEUE_CONNECTION</code> selects the queue connection. It falls back to
+                <code>QUEUE_CONNECTION</code> and then to <code>database</code>.
+            </li>
+            <li>
+                <code>FEED_QUEUE_NAME</code> selects a queue on that connection. Leave it unset to use the
+                connection's default queue.
+            </li>
+            <li>
+                <code>FEED_QUEUE_UNIQUE_TTL</code> sets the maximum lifetime of the uniqueness lock in seconds.
+                A second job for the same feed is not queued while that lock is active.
+            </li>
+        </list>
+
+        <note>
+            The <code>sync</code> connection executes each job immediately in the console process. Select an
+            asynchronous connection to move generation to a worker. Set <code>FEED_QUEUE_ENABLED=false</code> to
+            generate feeds directly without dispatching jobs.
+        </note>
+    </chapter>
+
     <chapter title="Schedule" id="schedule">
         <chapter title="Automatic" id="automatic">
             <p>

--- a/src/Commands/FeedGenerateCommand.php
+++ b/src/Commands/FeedGenerateCommand.php
@@ -47,7 +47,7 @@ class FeedGenerateCommand extends Command
     {
         $this->components->twoColumnDetail($feed, $this->textGreen('QUEUED'));
 
-        FeedJob::dispatch(app($feed));
+        FeedJob::dispatch($feed);
     }
 
     protected function performWithProgressBar(GeneratorService $generator, string $feed): void

--- a/src/Commands/FeedGenerateCommand.php
+++ b/src/Commands/FeedGenerateCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DragonCode\LaravelFeed\Commands;
 
 use DragonCode\LaravelFeed\Exceptions\InvalidFeedArgumentException;
+use DragonCode\LaravelFeed\Jobs\FeedJob;
 use DragonCode\LaravelFeed\Queries\FeedQuery;
 use DragonCode\LaravelFeed\Services\GeneratorService;
 use Illuminate\Console\Command;
@@ -25,7 +26,13 @@ class FeedGenerateCommand extends Command
     {
         foreach ($this->feedable($query) as $feed => $enabled) {
             if (! $enabled) {
-                $this->components->twoColumnDetail($feed, $this->messageYellow('SKIP'));
+                $this->components->twoColumnDetail($feed, $this->textYellow('SKIP'));
+
+                continue;
+            }
+
+            if ($this->hasQueue()) {
+                $this->performWithQueue($feed);
 
                 continue;
             }
@@ -34,6 +41,13 @@ class FeedGenerateCommand extends Command
                 ? $this->performWithProgressBar($generator, $feed)
                 : $this->performWithoutProgressBar($generator, $feed);
         }
+    }
+
+    protected function performWithQueue(string $feed): void
+    {
+        $this->components->twoColumnDetail($feed, $this->textGreen('QUEUED'));
+
+        FeedJob::dispatch(app($feed));
     }
 
     protected function performWithProgressBar(GeneratorService $generator, string $feed): void
@@ -65,7 +79,7 @@ class FeedGenerateCommand extends Command
         return [$feed->class => true];
     }
 
-    protected function messageYellow(string $message): string
+    protected function textYellow(string $message): string
     {
         if ($this->option('no-ansi')) {
             // @codeCoverageIgnoreStart
@@ -76,9 +90,25 @@ class FeedGenerateCommand extends Command
         return $this->yellow($message);
     }
 
+    protected function textGreen(string $message): string
+    {
+        if ($this->option('no-ansi')) {
+            // @codeCoverageIgnoreStart
+            return $message;
+            // @codeCoverageIgnoreEnd
+        }
+
+        return $this->green($message);
+    }
+
     protected function hasProgressBar(): bool
     {
-        return config()?->boolean('feeds.console.progress_bar');
+        return config()->boolean('feeds.console.progress_bar');
+    }
+
+    protected function hasQueue(): bool
+    {
+        return config()->boolean('feeds.queue.enabled');
     }
 
     protected function getArguments(): array

--- a/src/Helpers/ClassExistsHelper.php
+++ b/src/Helpers/ClassExistsHelper.php
@@ -6,6 +6,7 @@ namespace DragonCode\LaravelFeed\Helpers;
 
 use function class_exists;
 
+// @codeCoverageIgnoreStart
 class ClassExistsHelper
 {
     public function exists(string $class): bool
@@ -13,3 +14,4 @@ class ClassExistsHelper
         return class_exists($class);
     }
 }
+// @codeCoverageIgnoreEnd

--- a/src/Jobs/FeedJob.php
+++ b/src/Jobs/FeedJob.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DragonCode\LaravelFeed\Jobs;
+
+use DragonCode\LaravelFeed\Feeds\Feed;
+use DragonCode\LaravelFeed\Services\GeneratorService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+use function config;
+
+final class FeedJob implements ShouldBeUnique, ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(
+        public Feed $feed
+    ) {
+        $this->onConnection(config('feeds.queue.connection'));
+        $this->onQueue(config('feeds.queue.name'));
+        $this->onGroup(config('feeds.queue.group'));
+    }
+
+    public function handle(GeneratorService $generator): void
+    {
+        $generator->feed($this->feed);
+    }
+
+    public function uniqueId(): string
+    {
+        return $this->feed->filename();
+    }
+
+    public function uniqueFor(): int
+    {
+        return config('feeds.queue.unique_ttl');
+    }
+}

--- a/src/Jobs/FeedJob.php
+++ b/src/Jobs/FeedJob.php
@@ -13,6 +13,7 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 
+use function app;
 use function config;
 
 final class FeedJob implements ShouldBeUnique, ShouldQueue
@@ -23,25 +24,31 @@ final class FeedJob implements ShouldBeUnique, ShouldQueue
     use SerializesModels;
 
     public function __construct(
-        public Feed $feed
+        public string $feedClass
     ) {
         $this->onConnection(config('feeds.queue.connection'));
         $this->onQueue(config('feeds.queue.name'));
-        $this->onGroup(config('feeds.queue.group'));
     }
 
     public function handle(GeneratorService $generator): void
     {
-        $generator->feed($this->feed);
+        $generator->feed(
+            $this->resolve()
+        );
     }
 
     public function uniqueId(): string
     {
-        return $this->feed->filename();
+        return $this->feedClass;
     }
 
     public function uniqueFor(): int
     {
         return config('feeds.queue.unique_ttl');
+    }
+
+    protected function resolve(): Feed
+    {
+        return app($this->feedClass);
     }
 }

--- a/tests/.pest/snapshots/Feature/Console/Generation/QueueTest/queue.snap
+++ b/tests/.pest/snapshots/Feature/Console/Generation/QueueTest/queue.snap
@@ -1,0 +1,1 @@
+end of snapshots

--- a/tests/Feature/Console/Generation/QueueTest.php
+++ b/tests/Feature/Console/Generation/QueueTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use DragonCode\LaravelFeed\Commands\FeedGenerateCommand;
+use DragonCode\LaravelFeed\Jobs\FeedJob;
+use DragonCode\LaravelFeed\Models\Feed;
+use Illuminate\Support\Facades\Queue;
+use Workbench\App\Feeds\SitemapFeed;
+use Workbench\App\Feeds\YandexFeed;
+
+use function Pest\Laravel\artisan;
+
+test('queue', function () {
+    disableFeeds([
+        SitemapFeed::class,
+        YandexFeed::class,
+    ]);
+
+    config()->set([
+        'feeds.queue.enabled'    => true,
+        'feeds.queue.connection' => 'sync',
+        'feeds.queue.name'       => 'feeds',
+    ]);
+
+    Queue::fake()->serializeAndRestore();
+
+    artisan(FeedGenerateCommand::class)
+        ->expectsOutputToContain('QUEUED')
+        ->expectsOutputToContain('SKIP')
+        ->assertSuccessful()
+        ->run();
+
+    $active = getAllFeeds()->where('is_active', true);
+
+    Queue::assertPushed(FeedJob::class, $active->count());
+
+    $active->each(
+        fn (Feed $feed) => Queue::assertPushed(
+            FeedJob::class,
+            fn (FeedJob $job) => $job->feedClass === $feed->class
+                && $job->connection              === 'sync'
+                && $job->queue                   === 'feeds'
+        )
+    );
+
+    Queue::assertNotPushed(
+        FeedJob::class,
+        fn (FeedJob $job) => in_array($job->feedClass, [SitemapFeed::class, YandexFeed::class], true)
+    );
+});

--- a/tests/Unit/Architecture/JobTest.php
+++ b/tests/Unit/Architecture/JobTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+arch()
+    ->expect('DragonCode\LaravelFeed\Jobs')
+    ->toBeFinal();
+
+arch()
+    ->expect('DragonCode\LaravelFeed\Jobs')
+    ->toHaveSuffix('Job');
+
+arch()
+    ->expect('DragonCode\LaravelFeed\Jobs')
+    ->toImplement([ShouldQueue::class, ShouldBeUnique::class]);
+
+arch()
+    ->expect('DragonCode\LaravelFeed\Jobs')
+    ->toHaveMethod('uniqueId');
+
+arch()
+    ->expect('DragonCode\LaravelFeed\Jobs')
+    ->toHaveMethod('uniqueFor');

--- a/tests/Unit/Jobs/FeedJobTest.php
+++ b/tests/Unit/Jobs/FeedJobTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use DragonCode\LaravelFeed\Data\GenerationResultData;
+use DragonCode\LaravelFeed\Jobs\FeedJob;
+use DragonCode\LaravelFeed\Services\GeneratorService;
+use Workbench\App\Feeds\FullFeed;
+use Workbench\App\Feeds\SitemapFeed;
+
+test('configuration', function () {
+    config()->set([
+        'feeds.queue.connection' => 'redis',
+        'feeds.queue.name'       => 'feeds',
+        'feeds.queue.unique_ttl' => 120,
+    ]);
+
+    $job = new FeedJob(FullFeed::class);
+
+    expect($job->connection)->toBe('redis')
+        ->and($job->queue)->toBe('feeds')
+        ->and($job->uniqueFor())->toBe(120);
+});
+
+test('serialization', function () {
+    $job = unserialize(serialize(new FeedJob(FullFeed::class)));
+
+    expect($job)->toBeInstanceOf(FeedJob::class)
+        ->and($job->feedClass)->toBe(FullFeed::class);
+});
+
+test('generation', function () {
+    $feed = app(FullFeed::class);
+
+    app()->instance(FullFeed::class, $feed);
+
+    $generator = mock(GeneratorService::class);
+    $generator->shouldReceive('feed')
+        ->once()
+        ->with($feed)
+        ->andReturn(new GenerationResultData([], []));
+
+    (new FeedJob(FullFeed::class))->handle($generator);
+});
+
+test('unique id', function () {
+    $first  = new FeedJob(FullFeed::class);
+    $second = new FeedJob(SitemapFeed::class);
+
+    expect($first->uniqueId())->toBe(FullFeed::class)
+        ->and($second->uniqueId())->toBe(SitemapFeed::class)
+        ->and($first->uniqueId())->not->toBe($second->uniqueId());
+});


### PR DESCRIPTION
### What:

- [ ] Bug Fix
- [x] New Feature

### Description:

Adds optional Laravel Queue support for feed generation.

- Dispatches a unique job for each active feed when queue mode is enabled.
- Supports configurable queue connection, queue name, and uniqueness lock TTL.
- Keeps direct generation as the default behavior.
- Documents the queue settings and covers dispatching, configuration, serialization, generation, and architecture with tests.