### PR TITLE
feat(yandex): support custom category structures

### DIFF
--- a/.ai-factory/patches/2026-07-28-13.33.md
+++ b/.ai-factory/patches/2026-07-28-13.33.md
@@ -1,0 +1,27 @@
+# Yandex category named argument compatibility
+
+**Date:** 2026-07-28 13:33
+**Files:** src/Presets/Info/YandexFeedInfo.php, tests/Unit/Presets/Info/YandexFeedInfoTest.php
+**Severity:** high
+
+## Problem
+
+Calls using `category(id: 10, name: 'Electronics')` failed with `Unknown named parameter $name` after the second parameter was renamed to `$value`.
+
+## Root Cause
+
+The parameter rename treated its name as an internal implementation detail. PHP named arguments make public method parameter names part of the callable API, so changing `$name` broke existing consumers even though positional calls remained valid.
+
+## Solution
+
+Restored the public `$name` parameter while keeping its widened `array|string` type. The regression test now invokes the method with named arguments and verifies the serialized category structure.
+
+## Prevention
+
+- Treat public PHP parameter names as compatibility-sensitive API surface.
+- Preserve parameter names when widening types or changing internal semantics.
+- Cover established named-argument calls in public API regression tests.
+
+## Tags
+
+`#php` `#named-arguments` `#backward-compatibility` `#public-api` `#regression` `#yandex`

--- a/.ai-factory/patches/2026-07-28-13.56.md
+++ b/.ai-factory/patches/2026-07-28-13.56.md
@@ -1,0 +1,27 @@
+# Yandex category override compatibility
+
+**Date:** 2026-07-28 13:56
+**Files:** src/Presets/Info/YandexFeedInfo.php, tests/Unit/Presets/Info/YandexFeedInfoTest.php, docs/snippets/receipt-yandex-custom-categories.php, docs/topics/receipt-yandex.topic
+**Severity:** high
+
+## Problem
+
+Changing `YandexFeedInfo::category()` from `string $name` to `array|string $name` made existing subclass overrides with the original signature incompatible with the parent declaration and caused a fatal error when those classes were loaded.
+
+## Root Cause
+
+The new raw-array input was added by widening an overridable public method parameter. PHP method variance rules make the original parameter type part of the inheritance contract, so compatible calls at the parent level did not guarantee compatible subclass declarations.
+
+## Solution
+
+Restored the original `category(int|string $id, string $name, bool $replace = false)` contract and added `rawCategory()` for arbitrary category arrays. The `categories()` method now dispatches string values to `category()` and arrays to `rawCategory()`. Regression coverage includes a subclass with the legacy override and verifies both dispatch paths.
+
+## Prevention
+
+- Treat parameter types on non-final public methods as inheritance contracts.
+- Add new input forms through additive APIs when widening a parameter would invalidate existing overrides.
+- Test public API changes with representative subclasses, not only direct calls on the base class.
+
+## Tags
+
+`#php` `#inheritance` `#variance` `#backward-compatibility` `#public-api` `#regression` `#yandex`

--- a/docs/snippets/receipt-yandex-custom-categories.php
+++ b/docs/snippets/receipt-yandex-custom-categories.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 use DragonCode\LaravelFeed\Presets\Info\YandexFeedInfo;
 
-$info = (new YandexFeedInfo)->categories([
-    1 => 'Electronics',
-    [
+$info = (new YandexFeedInfo)
+    ->category(1, 'Electronics')
+    ->rawCategory([
         '@attributes' => [
             'id'       => 2,
             'parentId' => 1,
         ],
         '@value' => 'Smartphones',
-    ],
-]);
+    ]);

--- a/docs/snippets/receipt-yandex-custom-categories.php
+++ b/docs/snippets/receipt-yandex-custom-categories.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use DragonCode\LaravelFeed\Presets\Info\YandexFeedInfo;
+
+$info = (new YandexFeedInfo)->categories([
+    1 => 'Electronics',
+    [
+        '@attributes' => [
+            'id'       => 2,
+            'parentId' => 1,
+        ],
+        '@value' => 'Smartphones',
+    ],
+]);

--- a/docs/topics/receipt-yandex.topic
+++ b/docs/topics/receipt-yandex.topic
@@ -26,6 +26,21 @@
         <code-block lang="php" src="receipt-yandex-feed.php" />
     </chapter>
 
+    <chapter title="Custom category structure" id="custom_category_structure">
+        <p>
+            By default, <code>category()</code> and <code>categories()</code> build each category from its ID and name.
+            Pass an array as the category value when additional properties or another structure are required.
+            The array is added to the feed unchanged:
+        </p>
+
+        <code-block lang="php" src="receipt-yandex-custom-categories.php" include-lines="5-" />
+
+        <note>
+            Custom category arrays are not validated or transformed. Build them with the supported
+            <a href="directives.topic">XML directives</a>.
+        </note>
+    </chapter>
+
     <chapter title="Activate" id="activate">
         <include from="snippet-generate.topic" element-id="check_operation" />
     </chapter>

--- a/docs/topics/receipt-yandex.topic
+++ b/docs/topics/receipt-yandex.topic
@@ -28,12 +28,17 @@
 
     <chapter title="Custom category structure" id="custom_category_structure">
         <p>
-            By default, <code>category()</code> and <code>categories()</code> build each category from its ID and name.
-            Pass an array as the category value when additional properties or another structure are required.
+            By default, <code>category()</code> builds a category from its ID and name.
+            Use <code>rawCategory()</code> when additional properties or another structure are required.
             The array is added to the feed unchanged:
         </p>
 
         <code-block lang="php" src="receipt-yandex-custom-categories.php" include-lines="5-" />
+
+        <p>
+            The <code>categories()</code> method accepts both forms. It sends string values to
+            <code>category()</code> and array values to <code>rawCategory()</code>.
+        </p>
 
         <note>
             Custom category arrays are not validated or transformed. Build them with the supported

--- a/src/Presets/Info/YandexFeedInfo.php
+++ b/src/Presets/Info/YandexFeedInfo.php
@@ -90,7 +90,7 @@ class YandexFeedInfo extends FeedInfo
         return $this;
     }
 
-    public function category(int|string $id, array|string $name, bool $replace = false): static
+    public function category(int|string $id, string $name, bool $replace = false): static
     {
         if ($replace) {
             // @codeCoverageIgnoreStart
@@ -98,16 +98,21 @@ class YandexFeedInfo extends FeedInfo
             // @codeCoverageIgnoreEnd
         }
 
-        if (is_array($name)) {
-            $this->categories[] = $name;
-
-            return $this;
-        }
-
         $this->categories[] = [
             '@attributes' => ['id' => $id],
             '@value'      => $name,
         ];
+
+        return $this;
+    }
+
+    public function rawCategory(array $category, bool $replace = false): static
+    {
+        if ($replace) {
+            $this->categories = [];
+        }
+
+        $this->categories[] = $category;
 
         return $this;
     }
@@ -128,6 +133,12 @@ class YandexFeedInfo extends FeedInfo
         $this->categories = [];
 
         foreach ($categories as $id => $value) {
+            if (is_array($value)) {
+                $this->rawCategory($value);
+
+                continue;
+            }
+
             $this->category($id, $value);
         }
 

--- a/src/Presets/Info/YandexFeedInfo.php
+++ b/src/Presets/Info/YandexFeedInfo.php
@@ -7,8 +7,10 @@ namespace DragonCode\LaravelFeed\Presets\Info;
 use DragonCode\LaravelFeed\Feeds\Info\FeedInfo;
 use Illuminate\Support\Str;
 
+use function blank;
 use function collect;
 use function config;
+use function is_array;
 
 class YandexFeedInfo extends FeedInfo
 {
@@ -88,7 +90,7 @@ class YandexFeedInfo extends FeedInfo
         return $this;
     }
 
-    public function category(int|string $id, string $name, bool $replace = false): static
+    public function category(int|string $id, array|string $value, bool $replace = false): static
     {
         if ($replace) {
             // @codeCoverageIgnoreStart
@@ -96,9 +98,15 @@ class YandexFeedInfo extends FeedInfo
             // @codeCoverageIgnoreEnd
         }
 
+        if (is_array($value)) {
+            $this->categories[] = $value;
+
+            return $this;
+        }
+
         $this->categories[] = [
             '@attributes' => ['id' => $id],
-            '@value'      => $name,
+            '@value'      => $value,
         ];
 
         return $this;
@@ -119,8 +127,8 @@ class YandexFeedInfo extends FeedInfo
     {
         $this->categories = [];
 
-        foreach ($categories as $id => $name) {
-            $this->category($id, $name);
+        foreach ($categories as $id => $value) {
+            $this->category($id, $value);
         }
 
         return $this;

--- a/src/Presets/Info/YandexFeedInfo.php
+++ b/src/Presets/Info/YandexFeedInfo.php
@@ -90,7 +90,7 @@ class YandexFeedInfo extends FeedInfo
         return $this;
     }
 
-    public function category(int|string $id, array|string $value, bool $replace = false): static
+    public function category(int|string $id, array|string $name, bool $replace = false): static
     {
         if ($replace) {
             // @codeCoverageIgnoreStart
@@ -98,15 +98,15 @@ class YandexFeedInfo extends FeedInfo
             // @codeCoverageIgnoreEnd
         }
 
-        if (is_array($value)) {
-            $this->categories[] = $value;
+        if (is_array($name)) {
+            $this->categories[] = $name;
 
             return $this;
         }
 
         $this->categories[] = [
             '@attributes' => ['id' => $id],
-            '@value'      => $value,
+            '@value'      => $name,
         ];
 
         return $this;

--- a/tests/Unit/Presets/Info/YandexFeedInfoTest.php
+++ b/tests/Unit/Presets/Info/YandexFeedInfoTest.php
@@ -15,7 +15,14 @@ test('preserves the category name parameter for named arguments', function () {
     ]);
 });
 
-test('passes a custom category array through unchanged', function () {
+test('keeps category compatible with string-only overrides', function () {
+    $parameter = (new ReflectionMethod(YandexFeedInfo::class, 'category'))
+        ->getParameters()[1];
+
+    expect((string) $parameter->getType())->toBe('string');
+});
+
+test('passes a raw category array through unchanged', function () {
     $category = [
         '@attributes' => [
             'id'       => 20,
@@ -25,12 +32,14 @@ test('passes a custom category array through unchanged', function () {
         'custom' => ['enabled' => true],
     ];
 
-    $info = (new YandexFeedInfo)->category('ignored', $category);
+    $info = (new YandexFeedInfo)
+        ->category(10, 'Old category')
+        ->rawCategory($category, replace: true);
 
     expect($info->toArray()['categories']['@category'])->toBe([$category]);
 });
 
-test('accepts default and custom structures in a category collection', function () {
+test('dispatches mixed category collections without widening legacy overrides', function () {
     $category = [
         '@attributes' => [
             'id'       => 20,
@@ -39,16 +48,30 @@ test('accepts default and custom structures in a category collection', function 
         '@value' => 'Smartphones',
     ];
 
-    $info = (new YandexFeedInfo)->categories([
+    $info = new class extends YandexFeedInfo {
+        public array $categoryCalls = [];
+
+        public function category(int|string $id, string $name, bool $replace = false): static
+        {
+            $this->categoryCalls[] = [$id, $name, $replace];
+
+            return parent::category($id, $name, $replace);
+        }
+    };
+
+    $info->categories([
         10       => 'Electronics',
         'custom' => $category,
     ]);
 
-    expect($info->toArray()['categories']['@category'])->toBe([
-        [
-            '@attributes' => ['id' => 10],
-            '@value'      => 'Electronics',
-        ],
-        $category,
-    ]);
+    expect($info->categoryCalls)
+        ->toBe([[10, 'Electronics', false]])
+        ->and($info->toArray()['categories']['@category'])
+        ->toBe([
+            [
+                '@attributes' => ['id' => 10],
+                '@value'      => 'Electronics',
+            ],
+            $category,
+        ]);
 });

--- a/tests/Unit/Presets/Info/YandexFeedInfoTest.php
+++ b/tests/Unit/Presets/Info/YandexFeedInfoTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 use DragonCode\LaravelFeed\Presets\Info\YandexFeedInfo;
 
-test('serializes string category values with the preset structure', function () {
-    $info = (new YandexFeedInfo)->category(10, 'Electronics');
+test('preserves the category name parameter for named arguments', function () {
+    $info = (new YandexFeedInfo)->category(id: 10, name: 'Electronics');
 
     expect($info->toArray()['categories']['@category'])->toBe([
         [

--- a/tests/Unit/Presets/Info/YandexFeedInfoTest.php
+++ b/tests/Unit/Presets/Info/YandexFeedInfoTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use DragonCode\LaravelFeed\Presets\Info\YandexFeedInfo;
+
+test('serializes string category values with the preset structure', function () {
+    $info = (new YandexFeedInfo)->category(10, 'Electronics');
+
+    expect($info->toArray()['categories']['@category'])->toBe([
+        [
+            '@attributes' => ['id' => 10],
+            '@value'      => 'Electronics',
+        ],
+    ]);
+});
+
+test('passes a custom category array through unchanged', function () {
+    $category = [
+        '@attributes' => [
+            'id'       => 20,
+            'parentId' => 10,
+        ],
+        '@value' => 'Smartphones',
+        'custom' => ['enabled' => true],
+    ];
+
+    $info = (new YandexFeedInfo)->category('ignored', $category);
+
+    expect($info->toArray()['categories']['@category'])->toBe([$category]);
+});
+
+test('accepts default and custom structures in a category collection', function () {
+    $category = [
+        '@attributes' => [
+            'id'       => 20,
+            'parentId' => 10,
+        ],
+        '@value' => 'Smartphones',
+    ];
+
+    $info = (new YandexFeedInfo)->categories([
+        10       => 'Electronics',
+        'custom' => $category,
+    ]);
+
+    expect($info->toArray()['categories']['@category'])->toBe([
+        [
+            '@attributes' => ['id' => 10],
+            '@value'      => 'Electronics',
+        ],
+        $category,
+    ]);
+});


### PR DESCRIPTION
## Summary

- allow Yandex category values to be passed as raw arrays
- cover default, raw, and mixed category serialization
- document custom category structures in the Yandex recipe

## Why

Some Yandex feed schemas require category properties beyond the preset `id` and value structure. Raw array values are now passed through unchanged so callers can define the required converter structure.

## Validation

- `composer test` — 386 tests, 1927 assertions
- `XDEBUG_MODE=coverage composer test:coverage` — 100% coverage
- `composer test:type` — 100% type coverage
- `composer validate --strict --no-check-publish`
- Pint check for all changed PHP files
- Writerside topic XML and referenced files validation