### PR TITLE
Add feed-local transformer pipelines

### DIFF
--- a/src/Converters/Converter.php
+++ b/src/Converters/Converter.php
@@ -17,6 +17,8 @@ abstract class Converter
 
     protected array $transformers = [];
 
+    protected array $localTransformers = [];
+
     protected ?Closure $transformerPipeline = null;
 
     abstract public function footer(Feed $feed): string;
@@ -40,8 +42,20 @@ abstract class Converter
         return PHP_EOL;
     }
 
+    public function withLocalTransformers(array $transformers): static
+    {
+        $this->localTransformers = $transformers;
+
+        $this->transformerPipeline = null;
+
+        return $this;
+    }
+
     protected function transformValue(mixed $value): bool|float|int|string|null
     {
-        return ($this->transformerPipeline ??= $this->transformer->pipeline($this->transformers))($value);
+        return ($this->transformerPipeline ??= $this->transformer->pipeline(
+            $this->transformers,
+            $this->localTransformers
+        ))($value);
     }
 }

--- a/src/Feeds/Feed.php
+++ b/src/Feeds/Feed.php
@@ -43,6 +43,11 @@ abstract class Feed
         return new FeedItem($model);
     }
 
+    public function transformers(): array
+    {
+        return [];
+    }
+
     public function chunkSize(): int
     {
         return 1000;

--- a/src/Helpers/ConverterHelper.php
+++ b/src/Helpers/ConverterHelper.php
@@ -19,7 +19,7 @@ class ConverterHelper
         protected Container $container,
     ) {}
 
-    public function get(FeedFormatEnum $format): Converter
+    public function get(FeedFormatEnum $format, array $localTransformers = []): Converter
     {
         return $this->container->make(
             match ($format) {
@@ -29,6 +29,6 @@ class ConverterHelper
                 FeedFormatEnum::Csv       => CsvConverter::class,
                 FeedFormatEnum::Rss       => RssConverter::class,
             }
-        );
+        )->withLocalTransformers($localTransformers);
     }
 }

--- a/src/Services/GeneratorService.php
+++ b/src/Services/GeneratorService.php
@@ -243,7 +243,8 @@ class GeneratorService
     protected function converter(Feed $feed): Converter
     {
         return $this->converter->get(
-            $feed->format()
+            $feed->format(),
+            $feed->transformers()
         );
     }
 

--- a/src/Services/TransformerService.php
+++ b/src/Services/TransformerService.php
@@ -18,9 +18,9 @@ class TransformerService
         protected array $configuredTransformers,
     ) {}
 
-    public function pipeline(array $transformers = []): Closure
+    public function pipeline(array $transformers = [], array $localTransformers = []): Closure
     {
-        $pipeline = $this->transformers($transformers);
+        $pipeline = $this->transformers($transformers, $localTransformers);
 
         return static function (mixed $value) use ($pipeline): bool|float|int|string|null {
             foreach ($pipeline as $transformer) {
@@ -33,9 +33,10 @@ class TransformerService
         };
     }
 
-    protected function transformers(array $transformers): array
+    protected function transformers(array $transformers, array $localTransformers): array
     {
-        return (new Collection($this->configuredTransformers))
+        return (new Collection($localTransformers))
+            ->merge($this->configuredTransformers)
             ->merge($transformers)
             ->map(fn (string $transformer): Transformer => $this->container->make($transformer))
             ->unique()

--- a/tests/Unit/Converters/ConverterTest.php
+++ b/tests/Unit/Converters/ConverterTest.php
@@ -6,6 +6,16 @@ use DragonCode\LaravelFeed\Contracts\Transformer;
 use DragonCode\LaravelFeed\Converters\JsonConverter;
 use DragonCode\LaravelFeed\Feeds\Items\FeedItem;
 use DragonCode\LaravelFeed\Services\TransformerService;
+use DragonCode\LaravelFeed\Transformers\BoolTransformer;
+use DragonCode\LaravelFeed\Transformers\DateTimeTransformer;
+
+final class LocalDateTimeTransformer extends DateTimeTransformer
+{
+    protected function format(): string
+    {
+        return 'Y-m-d';
+    }
+}
 
 final class ConstructorConfiguredTransformer implements Transformer
 {
@@ -81,4 +91,28 @@ test('preserves info overrides during file-aware serialization', function () {
         ->toBe('{"name":"Laravel","overridden":"yes"},')
         ->and($converter->infoForFile(['name' => 'Laravel'], true, true))
         ->toBe('{"name":"Laravel","overridden":"yes"},');
+});
+
+test('applies local feed transformers before global transformers', function () {
+    $item = mock(FeedItem::class);
+    $item->shouldReceive('toArray')->once()->andReturn([
+        'published_at' => new DateTimeImmutable('2026-07-28T12:30:00+00:00'),
+        'active'       => true,
+    ]);
+
+    $converter = new JsonConverter(
+        JSON_THROW_ON_ERROR,
+        false,
+        new TransformerService(app(), [
+            DateTimeTransformer::class,
+            BoolTransformer::class,
+        ])
+    );
+
+    $converter->withLocalTransformers([
+        LocalDateTimeTransformer::class,
+    ]);
+
+    expect($converter->item($item, true))
+        ->toBe('{"published_at":"2026-07-28","active":"true"}');
 });

--- a/tests/Unit/Services/GeneratorServiceTest.php
+++ b/tests/Unit/Services/GeneratorServiceTest.php
@@ -10,6 +10,7 @@ use DragonCode\LaravelFeed\Helpers\ConverterHelper;
 use DragonCode\LaravelFeed\Queries\FeedQuery;
 use DragonCode\LaravelFeed\Services\FilesystemService;
 use DragonCode\LaravelFeed\Services\GeneratorService;
+use DragonCode\LaravelFeed\Transformers\DateTimeTransformer;
 use Illuminate\Filesystem\FilesystemAdapter;
 
 test('rejects publication that finishes without producing a generation result', function () {
@@ -20,6 +21,7 @@ test('rejects publication that finishes without producing a generation result', 
     $feed->shouldReceive('path')->once()->andReturn('feed.json');
     $feed->shouldReceive('storagePath')->once()->andReturn('feed.json');
     $feed->shouldReceive('format')->once()->andReturn(FeedFormatEnum::Json);
+    $feed->shouldReceive('transformers')->once()->andReturn([DateTimeTransformer::class]);
 
     $filesystem = mock(FilesystemService::class);
     $filesystem->shouldReceive('publishTo')
@@ -29,7 +31,10 @@ test('rejects publication that finishes without producing a generation result', 
     $converter = mock(Converter::class);
 
     $helper = mock(ConverterHelper::class);
-    $helper->shouldReceive('get')->once()->with(FeedFormatEnum::Json)->andReturn($converter);
+    $helper->shouldReceive('get')
+        ->once()
+        ->with(FeedFormatEnum::Json, [DateTimeTransformer::class])
+        ->andReturn($converter);
 
     $query = mock(FeedQuery::class);
     $query->shouldNotReceive('setLastActivity');

--- a/tests/Unit/Services/TransformerServiceTest.php
+++ b/tests/Unit/Services/TransformerServiceTest.php
@@ -7,6 +7,31 @@ use DragonCode\LaravelFeed\Services\TransformerService;
 
 final class TransformerPipelineDependency {}
 
+final class TransformerPipelineLocal implements Transformer
+{
+    public static int $instances = 0;
+
+    public static int $calls = 0;
+
+    public function __construct(
+        public TransformerPipelineDependency $dependency,
+    ) {
+        self::$instances++;
+    }
+
+    public function allow(mixed $value): bool
+    {
+        return is_string($value);
+    }
+
+    public function transform(mixed $value): string
+    {
+        self::$calls++;
+
+        return $value . ':local';
+    }
+}
+
 final class TransformerPipelineFirst implements Transformer
 {
     public static int $instances = 0;
@@ -58,6 +83,8 @@ final class TransformerPipelineSecond implements Transformer
 }
 
 beforeEach(function () {
+    TransformerPipelineLocal::$instances  = 0;
+    TransformerPipelineLocal::$calls      = 0;
     TransformerPipelineFirst::$instances  = 0;
     TransformerPipelineFirst::$calls      = 0;
     TransformerPipelineSecond::$instances = 0;
@@ -82,4 +109,29 @@ test('resolves an ordered transformer pipeline once through the container', func
         ->toBe(2)
         ->and(TransformerPipelineSecond::$calls)
         ->toBe(2);
+});
+
+test('runs local transformers before configured and converter transformers', function () {
+    app()->singleton(TransformerPipelineDependency::class);
+
+    $service  = new TransformerService(app(), [TransformerPipelineFirst::class]);
+    $pipeline = $service->pipeline(
+        [TransformerPipelineSecond::class],
+        [TransformerPipelineLocal::class]
+    );
+
+    expect($pipeline('value'))
+        ->toBe('value:local:first:second')
+        ->and(TransformerPipelineLocal::$instances)
+        ->toBe(1)
+        ->and(TransformerPipelineFirst::$instances)
+        ->toBe(1)
+        ->and(TransformerPipelineSecond::$instances)
+        ->toBe(1)
+        ->and(TransformerPipelineLocal::$calls)
+        ->toBe(1)
+        ->and(TransformerPipelineFirst::$calls)
+        ->toBe(1)
+        ->and(TransformerPipelineSecond::$calls)
+        ->toBe(1);
 });


### PR DESCRIPTION
## What changed

- added a per-feed `transformers()` hook
- passed local transformers into converter pipelines
- ordered transformers as local, configured global, then converter-specific
- preserved the existing global and converter transformer behavior
- added coverage for ordering, local date formatting, global fallback behavior, and feed-to-converter wiring

## Why

Individual feeds can now override value transformation without changing the global `feeds.transformers` configuration. This supports cases such as a feed-specific date format while keeping global transformers active.

## Validation

- `vendor/bin/pint --dirty --ansi`
- `composer test` — 391 tests, 1941 assertions
- `XDEBUG_MODE=coverage composer test:coverage` — 100.0%
- `composer test:type` — 100.0%