### PR TITLE
docs(transformers): document feed-local pipelines

### DIFF
--- a/docs/snippets/advanced-extends-transformer-feed.php
+++ b/docs/snippets/advanced-extends-transformer-feed.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Feeds;
+
+use App\Feeds\Transformers\PriceTransformer;
+use App\Models\Product;
+use DragonCode\LaravelFeed\Feeds\Feed;
+use Illuminate\Database\Eloquent\Builder;
+
+class ProductFeed extends Feed
+{
+    public function builder(): Builder
+    {
+        return Product::query();
+    }
+
+    public function transformers(): array
+    {
+        return [
+            PriceTransformer::class,
+        ];
+    }
+}

--- a/docs/topics/extending-functionality.topic
+++ b/docs/topics/extending-functionality.topic
@@ -74,24 +74,38 @@
 
     <chapter title="Custom transformers" id="custom_transformers">
         <p>
-            A transformer converts a supported value before the converter serializes it. Register transformer class
-            names in <path>config/feeds.php</path>. Laravel resolves each class through the service container, so
-            constructor dependencies and custom container bindings are supported.
+            A transformer converts a supported value before the converter serializes it. Laravel resolves transformer
+            classes through the service container, so constructor dependencies and custom container bindings are
+            supported.
         </p>
 
         <code-block lang="php" src="advanced-extends-transformer.php" include-lines="5-" />
 
         <p>
-            Add the transformer to the configured list after the built-in transformers:
+            To apply the transformer to every feed, add it to the <code>transformers</code> list in
+            <path>config/feeds.php</path> after the built-in transformers:
         </p>
 
         <code-block lang="php" src="advanced-extends-transformer-config.php" />
 
         <p>
-            The configured transformers run in declaration order. Converter-specific transformers are appended after
-            the configured list. Each <code>allow()</code> call receives the current value, including changes made by
-            earlier transformers, and every matching transformer may update it. Duplicate entries are removed after
-            container resolution while the first occurrence keeps its position.
+            To apply the transformer to one feed only, leave it out of the global configuration and return its class
+            from the feed's <code>transformers()</code> method:
+        </p>
+
+        <code-block lang="php" src="advanced-extends-transformer-feed.php" include-lines="5-" />
+
+        <note>
+            This is useful when one feed needs a different date format. A local date transformer can convert the date
+            to the required string before the configured <code>DateTimeTransformer</code> checks it. Other configured
+            transformers remain active.
+        </note>
+
+        <p>
+            Local transformers run first in declaration order. The globally configured transformers run next, and
+            converter-specific transformers run last. Each <code>allow()</code> call receives the current value,
+            including changes made by earlier transformers, and every matching transformer may update it. Duplicate
+            entries are removed after container resolution while the first occurrence keeps its position.
         </p>
 
         <p>


### PR DESCRIPTION
## What changed

- documented global and feed-local transformer registration
- added a complete `Feed::transformers()` example
- documented the `local → global → converter-specific` execution order
- described the feed-specific date-formatting case

## Context

Documentation follow-up for #229, which introduced feed-local transformers and has already been merged into `1.x`.

## Validation

- PHP snippet syntax check
- Writerside topic XML parsing
- `composer style:snippets`
- `composer test` — 391 tests, 1941 assertions
- `git diff --check`