### PR TITLE
Use Eloquent builder contract for feeds

### DIFF
--- a/src/Feeds/Feed.php
+++ b/src/Feeds/Feed.php
@@ -9,7 +9,7 @@ use DragonCode\LaravelFeed\Enums\FeedFormatEnum;
 use DragonCode\LaravelFeed\Exceptions\UnsupportedStorageDiskException;
 use DragonCode\LaravelFeed\Feeds\Info\FeedInfo;
 use DragonCode\LaravelFeed\Feeds\Items\FeedItem;
-use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Contracts\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Foundation\Application;


### PR DESCRIPTION
## Summary

- Type `Feed::builder()` against `Illuminate\Contracts\Database\Eloquent\Builder`.
- Keep existing concrete `Illuminate\Database\Eloquent\Builder` return types compatible through covariance.

## Why

The base feed API should depend on Laravel's Eloquent builder contract instead of the concrete implementation.

## Impact

Existing feed implementations remain compatible. Custom implementations may return any builder that satisfies the Laravel contract.

## Validation

- `vendor\bin\pint --test src\Feeds\Feed.php`
- `vendor\bin\pest --colors=never --compact` — 397 tests passed with 2022 assertions.