### PR TITLE
Harden feed generation command

### DIFF
--- a/src/Commands/FeedGenerateCommand.php
+++ b/src/Commands/FeedGenerateCommand.php
@@ -32,35 +32,31 @@ final class FeedGenerateCommand extends Command
     use Colors;
 
     private const AGENT_JSON_FLAGS = JSON_THROW_ON_ERROR
-        | JSON_UNESCAPED_SLASHES
-        | JSON_INVALID_UTF8_SUBSTITUTE;
+    | JSON_UNESCAPED_SLASHES
+    | JSON_INVALID_UTF8_SUBSTITUTE;
 
-    public function handle(
-        GeneratorService $generator,
-        FeedQuery $query,
-        AgentDetectorService $agentDetector,
-    ): int {
+    public function handle(GeneratorService $generator, FeedQuery $query, AgentDetectorService $agentDetector): int
+    {
         $feedId        = $this->feedId();
         $feeds         = $this->selectedFeeds($query, $feedId);
         $isTargetedRun = $feedId !== null;
         $usesQueue     = $this->usesQueue();
 
-        if ($agentDetector->isAgent()) {
-            $this->runForAgent($generator, $feeds, $isTargetedRun, $usesQueue);
-        } else {
-            $this->runForConsole(
-                $generator,
-                $feeds,
-                $isTargetedRun,
-                $usesQueue,
-                $this->usesProgressBar()
-            );
-        }
+        $agentDetector->isAgent()
+            ? $this->runForAgent($generator, $feeds, $isTargetedRun, $usesQueue)
+            : $this->runForConsole($generator, $feeds, $isTargetedRun, $usesQueue, $this->usesProgressBar());
 
         return self::SUCCESS;
     }
 
-    private function runForConsole(
+    protected function getArguments(): array
+    {
+        return [
+            ['feed', InputArgument::OPTIONAL, 'The Feed ID for generation (from the database)'],
+        ];
+    }
+
+    protected function runForConsole(
         GeneratorService $generator,
         Collection $feeds,
         bool $isTargetedRun,
@@ -84,7 +80,7 @@ final class FeedGenerateCommand extends Command
         }
     }
 
-    private function runForAgent(
+    protected function runForAgent(
         GeneratorService $generator,
         Collection $feeds,
         bool $isTargetedRun,
@@ -99,7 +95,7 @@ final class FeedGenerateCommand extends Command
         $this->writeAgentOutput($results);
     }
 
-    private function runFeedForAgent(
+    protected function runFeedForAgent(
         GeneratorService $generator,
         Feed $feed,
         bool $isTargetedRun,
@@ -124,7 +120,7 @@ final class FeedGenerateCommand extends Command
         return $this->generatedAgentResult($feed->class, $generator->feed(app($feed->class)));
     }
 
-    private function writeAgentOutput(array $feeds): void
+    protected function writeAgentOutput(array $feeds): void
     {
         $this->output->writeln(json_encode([
             'tool'   => 'feed:generate',
@@ -133,7 +129,7 @@ final class FeedGenerateCommand extends Command
         ], self::AGENT_JSON_FLAGS), OutputInterface::OUTPUT_RAW);
     }
 
-    private function generatedAgentResult(string $feed, GenerationResultData $result): array
+    protected function generatedAgentResult(string $feed, GenerationResultData $result): array
     {
         $files = [];
 
@@ -151,19 +147,19 @@ final class FeedGenerateCommand extends Command
         ];
     }
 
-    private function showSkippedFeed(string $feed): void
+    protected function showSkippedFeed(string $feed): void
     {
         $this->components->twoColumnDetail($feed, $this->textYellow('SKIP'));
     }
 
-    private function dispatchFeed(string $feed): void
+    protected function dispatchFeed(string $feed): void
     {
         $this->components->twoColumnDetail($feed, $this->textGreen('QUEUED'));
 
         FeedJob::dispatch($feed);
     }
 
-    private function generateFeed(GeneratorService $generator, string $feed, bool $usesProgressBar): void
+    protected function generateFeed(GeneratorService $generator, string $feed, bool $usesProgressBar): void
     {
         if ($usesProgressBar) {
             $this->components->info($feed);
@@ -176,7 +172,7 @@ final class FeedGenerateCommand extends Command
         $this->components->task($feed, fn () => $generator->feed(app($feed)));
     }
 
-    private function selectedFeeds(FeedQuery $query, ?int $feedId): Collection
+    protected function selectedFeeds(FeedQuery $query, ?int $feedId): Collection
     {
         if ($feedId === null) {
             return $query->all()->get();
@@ -185,7 +181,7 @@ final class FeedGenerateCommand extends Command
         return new Collection([$query->find($feedId)]);
     }
 
-    private function feedId(): ?int
+    protected function feedId(): ?int
     {
         $value = $this->argument('feed');
 
@@ -216,7 +212,7 @@ final class FeedGenerateCommand extends Command
         return $id;
     }
 
-    private function textYellow(string $message): string
+    protected function textYellow(string $message): string
     {
         if ($this->option('no-ansi')) {
             // @codeCoverageIgnoreStart
@@ -227,7 +223,7 @@ final class FeedGenerateCommand extends Command
         return $this->yellow($message);
     }
 
-    private function textGreen(string $message): string
+    protected function textGreen(string $message): string
     {
         if ($this->option('no-ansi')) {
             // @codeCoverageIgnoreStart
@@ -238,20 +234,13 @@ final class FeedGenerateCommand extends Command
         return $this->green($message);
     }
 
-    private function usesProgressBar(): bool
+    protected function usesProgressBar(): bool
     {
         return config()->boolean('feeds.console.progress_bar');
     }
 
-    private function usesQueue(): bool
+    protected function usesQueue(): bool
     {
         return config()->boolean('feeds.queue.enabled');
-    }
-
-    protected function getArguments(): array
-    {
-        return [
-            ['feed', InputArgument::OPTIONAL, 'The Feed ID for generation (from the database)'],
-        ];
     }
 }

--- a/src/Commands/FeedGenerateCommand.php
+++ b/src/Commands/FeedGenerateCommand.php
@@ -7,10 +7,12 @@ namespace DragonCode\LaravelFeed\Commands;
 use DragonCode\LaravelFeed\Data\GenerationResultData;
 use DragonCode\LaravelFeed\Exceptions\InvalidFeedArgumentException;
 use DragonCode\LaravelFeed\Jobs\FeedJob;
+use DragonCode\LaravelFeed\Models\Feed;
 use DragonCode\LaravelFeed\Queries\FeedQuery;
 use DragonCode\LaravelFeed\Services\AgentDetectorService;
 use DragonCode\LaravelFeed\Services\GeneratorService;
 use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Collection;
 use Laravel\Prompts\Concerns\Colors;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
@@ -18,82 +20,120 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 use function app;
 use function config;
-use function is_numeric;
+use function filter_var;
+use function is_int;
+use function is_string;
 use function json_encode;
+use function preg_match;
 
 #[AsCommand('feed:generate', 'Generate XML feeds')]
 final class FeedGenerateCommand extends Command
 {
     use Colors;
 
+    private const AGENT_JSON_FLAGS = JSON_THROW_ON_ERROR
+        | JSON_UNESCAPED_SLASHES
+        | JSON_INVALID_UTF8_SUBSTITUTE;
+
     public function handle(
         GeneratorService $generator,
         FeedQuery $query,
         AgentDetectorService $agentDetector,
-    ): void {
-        $feeds = $this->feedable($query);
+    ): int {
+        $feedId        = $this->feedId();
+        $feeds         = $this->selectedFeeds($query, $feedId);
+        $isTargetedRun = $feedId !== null;
+        $usesQueue     = $this->usesQueue();
 
         if ($agentDetector->isAgent()) {
-            $this->performForAgent($generator, $feeds);
-
-            return;
+            $this->runForAgent($generator, $feeds, $isTargetedRun, $usesQueue);
+        } else {
+            $this->runForConsole(
+                $generator,
+                $feeds,
+                $isTargetedRun,
+                $usesQueue,
+                $this->usesProgressBar()
+            );
         }
 
-        foreach ($feeds as $feed => $enabled) {
-            if (! $enabled) {
-                $this->components->twoColumnDetail($feed, $this->textYellow('SKIP'));
+        return self::SUCCESS;
+    }
+
+    private function runForConsole(
+        GeneratorService $generator,
+        Collection $feeds,
+        bool $isTargetedRun,
+        bool $usesQueue,
+        bool $usesProgressBar,
+    ): void {
+        foreach ($feeds as $feed) {
+            if (! $isTargetedRun && ! $feed->is_active) {
+                $this->showSkippedFeed($feed->class);
 
                 continue;
             }
 
-            if ($this->hasQueue()) {
-                $this->performWithQueue($feed);
+            if ($usesQueue) {
+                $this->dispatchFeed($feed->class);
 
                 continue;
             }
 
-            $this->hasProgressBar()
-                ? $this->performWithProgressBar($generator, $feed)
-                : $this->performWithoutProgressBar($generator, $feed);
+            $this->generateFeed($generator, $feed->class, $usesProgressBar);
         }
     }
 
-    protected function performForAgent(GeneratorService $generator, array $feeds): void
-    {
+    private function runForAgent(
+        GeneratorService $generator,
+        Collection $feeds,
+        bool $isTargetedRun,
+        bool $usesQueue,
+    ): void {
         $results = [];
 
-        foreach ($feeds as $feed => $enabled) {
-            if (! $enabled) {
-                $results[] = [
-                    'class'  => $feed,
-                    'status' => 'skipped',
-                ];
-
-                continue;
-            }
-
-            if ($this->hasQueue()) {
-                FeedJob::dispatchSync($feed);
-
-                $results[] = [
-                    'class'  => $feed,
-                    'status' => 'queued',
-                ];
-
-                continue;
-            }
-
-            $results[] = $this->generatedFeed($feed, $generator->feed(app($feed)));
+        foreach ($feeds as $feed) {
+            $results[] = $this->runFeedForAgent($generator, $feed, $isTargetedRun, $usesQueue);
         }
 
+        $this->writeAgentOutput($results);
+    }
+
+    private function runFeedForAgent(
+        GeneratorService $generator,
+        Feed $feed,
+        bool $isTargetedRun,
+        bool $usesQueue,
+    ): array {
+        if (! $isTargetedRun && ! $feed->is_active) {
+            return [
+                'class'  => $feed->class,
+                'status' => 'skipped',
+            ];
+        }
+
+        if ($usesQueue) {
+            FeedJob::dispatchSync($feed->class);
+
+            return [
+                'class'  => $feed->class,
+                'status' => 'queued',
+            ];
+        }
+
+        return $this->generatedAgentResult($feed->class, $generator->feed(app($feed->class)));
+    }
+
+    private function writeAgentOutput(array $feeds): void
+    {
         $this->output->writeln(json_encode([
             'tool'   => 'feed:generate',
             'result' => 'success',
-            'feeds'  => $results,
-        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE), OutputInterface::OUTPUT_RAW);
+            'feeds'  => $feeds,
+        ], self::AGENT_JSON_FLAGS), OutputInterface::OUTPUT_RAW);
     }
 
-    protected function generatedFeed(string $feed, GenerationResultData $result): array
+    private function generatedAgentResult(string $feed, GenerationResultData $result): array
     {
         $files = [];
 
@@ -111,43 +151,72 @@ final class FeedGenerateCommand extends Command
         ];
     }
 
-    protected function performWithQueue(string $feed): void
+    private function showSkippedFeed(string $feed): void
+    {
+        $this->components->twoColumnDetail($feed, $this->textYellow('SKIP'));
+    }
+
+    private function dispatchFeed(string $feed): void
     {
         $this->components->twoColumnDetail($feed, $this->textGreen('QUEUED'));
 
         FeedJob::dispatch($feed);
     }
 
-    protected function performWithProgressBar(GeneratorService $generator, string $feed): void
+    private function generateFeed(GeneratorService $generator, string $feed, bool $usesProgressBar): void
     {
-        $this->components->info($feed);
+        if ($usesProgressBar) {
+            $this->components->info($feed);
 
-        $generator->feed(app($feed), $this->output);
-    }
+            $generator->feed(app($feed), $this->output);
 
-    protected function performWithoutProgressBar(GeneratorService $generator, string $feed): void
-    {
+            return;
+        }
+
         $this->components->task($feed, fn () => $generator->feed(app($feed)));
     }
 
-    protected function feedable(FeedQuery $feeds): array
+    private function selectedFeeds(FeedQuery $query, ?int $feedId): Collection
     {
-        if (! $id = $this->argument('feed')) {
-            return $feeds->all()
-                ->pluck('is_active', 'class')
-                ->all();
+        if ($feedId === null) {
+            return $query->all()->get();
         }
 
-        if (! is_numeric($id)) {
-            throw new InvalidFeedArgumentException($id);
-        }
-
-        $feed = $feeds->find((int) $id);
-
-        return [$feed->class => true];
+        return new Collection([$query->find($feedId)]);
     }
 
-    protected function textYellow(string $message): string
+    private function feedId(): ?int
+    {
+        $value = $this->argument('feed');
+
+        if ($value === null) {
+            return null;
+        }
+
+        if (is_int($value)) {
+            if ($value < 1) {
+                throw new InvalidFeedArgumentException($value);
+            }
+
+            return $value;
+        }
+
+        if (! is_string($value) || preg_match('/^[1-9][0-9]*$/D', $value) !== 1) {
+            throw new InvalidFeedArgumentException($value);
+        }
+
+        $id = filter_var($value, FILTER_VALIDATE_INT, [
+            'options' => ['min_range' => 1],
+        ]);
+
+        if ($id === false) {
+            throw new InvalidFeedArgumentException($value);
+        }
+
+        return $id;
+    }
+
+    private function textYellow(string $message): string
     {
         if ($this->option('no-ansi')) {
             // @codeCoverageIgnoreStart
@@ -158,7 +227,7 @@ final class FeedGenerateCommand extends Command
         return $this->yellow($message);
     }
 
-    protected function textGreen(string $message): string
+    private function textGreen(string $message): string
     {
         if ($this->option('no-ansi')) {
             // @codeCoverageIgnoreStart
@@ -169,12 +238,12 @@ final class FeedGenerateCommand extends Command
         return $this->green($message);
     }
 
-    protected function hasProgressBar(): bool
+    private function usesProgressBar(): bool
     {
         return config()->boolean('feeds.console.progress_bar');
     }
 
-    protected function hasQueue(): bool
+    private function usesQueue(): bool
     {
         return config()->boolean('feeds.queue.enabled');
     }

--- a/tests/.pest/snapshots/Feature/Console/Generation/AgentTest/does_not_emit_a_success_response_when_generation_fails.snap
+++ b/tests/.pest/snapshots/Feature/Console/Generation/AgentTest/does_not_emit_a_success_response_when_generation_fails.snap
@@ -1,0 +1,1 @@
+end of snapshots

--- a/tests/.pest/snapshots/Feature/Console/Generation/IncorrectParameterTest/rejects_ambiguous_numeric_feed_IDs.snap
+++ b/tests/.pest/snapshots/Feature/Console/Generation/IncorrectParameterTest/rejects_ambiguous_numeric_feed_IDs.snap
@@ -1,0 +1,1 @@
+end of snapshots

--- a/tests/Feature/Console/Generation/AgentTest.php
+++ b/tests/Feature/Console/Generation/AgentTest.php
@@ -3,12 +3,16 @@
 declare(strict_types=1);
 
 use DragonCode\LaravelFeed\Commands\FeedGenerateCommand;
+use DragonCode\LaravelFeed\Exceptions\FeedGenerationException;
 use DragonCode\LaravelFeed\Jobs\FeedJob;
 use DragonCode\LaravelFeed\Models\Feed;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Bus;
 use Symfony\Component\Console\Command\Command;
+use Workbench\App\Data\NewsFakeData;
+use Workbench\App\Feeds\FailedFeed;
 use Workbench\App\Feeds\SitemapFeed;
+use Workbench\App\Feeds\SplitPerFileFeed;
 use Workbench\App\Feeds\YandexFeed;
 
 test('returns generated files and record counts to an AI agent', function () {
@@ -16,31 +20,45 @@ test('returns generated files and record counts to an AI agent', function () {
 
     config()->set('feeds.console.progress_bar', true);
 
-    $record  = findFeed(SitemapFeed::class);
-    $feed    = app($record->class);
-    $records = $feed->builder()->count();
+    createNews(...NewsFakeData::toArray());
+
+    $record = findFeed(SplitPerFileFeed::class);
+    $feed   = app($record->class);
 
     $status = Artisan::call(FeedGenerateCommand::class, [
         'feed' => $record->id,
     ]);
 
-    $output = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+    $raw      = Artisan::output();
+    $output   = json_decode($raw, true, flags: JSON_THROW_ON_ERROR);
+    $expected = [
+        'tool'   => 'feed:generate',
+        'result' => 'success',
+        'feeds'  => [[
+            'class'  => SplitPerFileFeed::class,
+            'status' => 'generated',
+            'files'  => [
+                [
+                    'path'    => $feed->path(1),
+                    'records' => 2,
+                ],
+                [
+                    'path'    => $feed->path(2),
+                    'records' => 1,
+                ],
+            ],
+        ]],
+    ];
 
     expect($status)
         ->toBe(Command::SUCCESS)
         ->and($output)
-        ->toBe([
-            'tool'   => 'feed:generate',
-            'result' => 'success',
-            'feeds'  => [[
-                'class'  => SitemapFeed::class,
-                'status' => 'generated',
-                'files'  => [[
-                    'path'    => $feed->path(),
-                    'records' => $records,
-                ]],
-            ]],
-        ]);
+        ->toBe($expected)
+        ->and($raw)
+        ->toBe(json_encode(
+            $expected,
+            JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE
+        ) . PHP_EOL);
 });
 
 test('returns queued and skipped feeds to an AI agent', function () {
@@ -79,4 +97,28 @@ test('returns queued and skipped feeds to an AI agent', function () {
         ]);
 
     Bus::assertDispatchedSync(FeedJob::class, $feeds->where('is_active', true)->count());
+
+    $feeds->where('is_active', true)->each(
+        fn (Feed $feed) => Bus::assertDispatchedSync(
+            FeedJob::class,
+            fn (FeedJob $job) => $job->feedClass === $feed->class
+        )
+    );
 });
+
+test('does not emit a success response when generation fails', function () {
+    mockAgent(true);
+
+    $feed = Feed::create([
+        'class' => FailedFeed::class,
+        'title' => 'Failed',
+    ]);
+
+    try {
+        Artisan::call(FeedGenerateCommand::class, ['feed' => $feed->id]);
+    } catch (FeedGenerationException $exception) {
+        expect(Artisan::output())->not->toContain('"result":"success"');
+
+        throw $exception;
+    }
+})->throws(FeedGenerationException::class, 'Something went wrong while generating the feed.');

--- a/tests/Feature/Console/Generation/DefaultTest.php
+++ b/tests/Feature/Console/Generation/DefaultTest.php
@@ -14,6 +14,8 @@ test('generate', function () {
         fn (Feed $feed) => $command->expectsOutputToContain($feed->class)
     );
 
+    $command->doesntExpectOutputToContain('"tool":"feed:generate"');
+
     $command->assertSuccessful()->run();
 
     getAllFeeds()->each(

--- a/tests/Feature/Console/Generation/IncorrectParameterTest.php
+++ b/tests/Feature/Console/Generation/IncorrectParameterTest.php
@@ -14,3 +14,21 @@ test('incorrect', function (mixed $id) {
 })
     ->throws(InvalidFeedArgumentException::class, 'Feed ID must be of type integer, [string] given.')
     ->with('generation invalid');
+
+test('rejects ambiguous numeric feed IDs', function () {
+    foreach ([
+        0,
+        1.0,
+        '0',
+        '-1',
+        '1.9',
+        '1e2',
+        '+1',
+        ' 1 ',
+        '9999999999999999999999999999999999999999',
+    ] as $id) {
+        expect(fn () => artisan(FeedGenerateCommand::class, [
+            'feed' => $id,
+        ])->run())->toThrow(InvalidFeedArgumentException::class);
+    }
+});

--- a/tests/Feature/Console/Generation/SpecifiedTest.php
+++ b/tests/Feature/Console/Generation/SpecifiedTest.php
@@ -9,10 +9,12 @@ use Workbench\App\Feeds\SitemapFeed;
 use function Pest\Laravel\artisan;
 
 test('generate', function () {
+    disableFeeds([SitemapFeed::class]);
+
     $source = findFeed(SitemapFeed::class);
 
     $command = artisan(FeedGenerateCommand::class, [
-        'feed' => $source->id,
+        'feed' => (string) $source->id,
     ]);
 
     getAllFeeds()->each(


### PR DESCRIPTION
## Summary

- separate interactive and AI-agent execution paths in `feed:generate`
- keep feed models intact through selection and make the success exit code explicit
- reject ambiguous feed identifiers such as `0`, decimals, scientific notation, signed values, whitespace, and integer overflow
- strengthen regression coverage for split-file JSON output, synchronous queue dispatch, failure behavior, and targeted inactive feeds

## Why

The agent-friendly output added in #239 duplicated command orchestration and relied on `is_numeric()` for feed selection. Inputs such as `0`, `1.9`, or `1e2` could run all feeds or silently select a different feed.

This refactor isolates the two output modes while preserving the documented contract from #239 and #240.

## Impact

- regular human console output remains unchanged
- agent output keeps the existing `generated`, `queued`, and `skipped` JSON shapes
- agent queue jobs still run synchronously before the response is emitted
- explicitly selected inactive feeds still run
- ambiguous feed IDs now fail instead of targeting another feed

## Validation

- `composer test` — 402 tests, 2073 assertions
- `XDEBUG_MODE=coverage composer test:coverage` — 100% code coverage
- `composer test:type` — 100% type coverage
- `vendor/bin/pint --test`
- `git diff --check`