### PR TITLE
Refresh Context7 after documentation deployment

### DIFF
--- a/.ai-factory/patches/2026-08-08-15.04.md
+++ b/.ai-factory/patches/2026-08-08-15.04.md
@@ -1,0 +1,27 @@
+# Documentation workflow test assumed refresh stayed in deploy job
+
+**Date:** 2026-08-08 15:04
+**Files:** tests/Unit/DocumentationWorkflowTest.php
+**Severity:** medium
+
+## Problem
+
+`DocumentationWorkflowTest` failed with `Undefined array key 1` after the Context7 refresh moved from the second `deploy` step into a separate `context7` job.
+
+## Root Cause
+
+The test located the refresh command through the positional `$deploySteps[1]` index. That coupled the contract to the old job layout and did not represent the new `context7` dependency on `deploy`.
+
+## Solution
+
+Added a command-based step locator, loaded the refresh step from the `context7` job, asserted its dependency and permissions, and included its steps in the pinned-action check.
+
+## Prevention
+
+- Locate workflow run steps by stable command behavior instead of array position.
+- Update job dependency assertions when moving a step into a separate job.
+- Include every workflow job in shared action security checks.
+
+## Tags
+
+`#github-actions` `#workflow` `#testing` `#regression` `#context7`

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -87,9 +87,21 @@ jobs:
                 env:
                     CONTEXT7_API_KEY: ${{ secrets.CONTEXT7_API_KEY }}
                 run: |
-                    curl --fail-with-body --silent --show-error \
+                    response=$(curl --silent --show-error \
                         --request POST \
                         --url https://context7.com/api/v1/refresh \
                         --header "Authorization: Bearer ${CONTEXT7_API_KEY}" \
                         --header "Content-Type: application/json" \
-                        --data '{"libraryName":"/llmstxt/feeds_dragon-code_pro_llms_txt"}'
+                        --data '{"libraryName":"/llmstxt/feeds_dragon-code_pro_llms_txt"}' \
+                        --write-out '\n%{http_code}')
+                    status="${response##*$'\n'}"
+                    body="${response%$'\n'*}"
+
+                    if [[ "${status}" == 2* ]]; then
+                        printf '%s\n' "${body}"
+                    elif [[ "${status}" == "400" && "${body}" == *"user-has-active-task"* ]]; then
+                        printf '%s\n' "Context7 refresh is already in progress."
+                    else
+                        printf '%s\n' "${body}" >&2
+                        exit 1
+                    fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -73,3 +73,14 @@ jobs:
             -   name: Deploy documentation
                 id: deployment
                 uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128
+
+            -   name: Refresh Context7 documentation
+                env:
+                    CONTEXT7_API_KEY: ${{ secrets.CONTEXT7_API_KEY }}
+                run: |
+                    curl --fail-with-body --silent --show-error \
+                        --request POST \
+                        --url https://context7.com/api/v1/refresh \
+                        --header "Authorization: Bearer ${CONTEXT7_API_KEY}" \
+                        --header "Content-Type: application/json" \
+                        --data '{"libraryName":"/llmstxt/feeds_dragon-code_pro_llms_txt"}'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -74,17 +74,6 @@ jobs:
                 id: deployment
                 uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128
 
-            -   name: Refresh Context7 documentation
-                env:
-                    CONTEXT7_API_KEY: ${{ secrets.CONTEXT7_API_KEY }}
-                run: |
-                    curl --fail-with-body --silent --show-error \
-                        --request POST \
-                        --url https://context7.com/api/v1/refresh \
-                        --header "Authorization: Bearer ${CONTEXT7_API_KEY}" \
-                        --header "Content-Type: application/json" \
-                        --data '{"libraryName":"/llmstxt/feeds_dragon-code_pro_llms_txt"}'
-
     context7:
         name: Refresh Context7
         needs: deploy

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -84,3 +84,23 @@ jobs:
                         --header "Authorization: Bearer ${CONTEXT7_API_KEY}" \
                         --header "Content-Type: application/json" \
                         --data '{"libraryName":"/llmstxt/feeds_dragon-code_pro_llms_txt"}'
+
+    context7:
+        name: Refresh Context7
+        needs: deploy
+        permissions:
+            id-token: write
+        runs-on: ubuntu-latest
+        timeout-minutes: 5
+
+        steps:
+            -   name: Refresh documentation
+                env:
+                    CONTEXT7_API_KEY: ${{ secrets.CONTEXT7_API_KEY }}
+                run: |
+                    curl --fail-with-body --silent --show-error \
+                        --request POST \
+                        --url https://context7.com/api/v1/refresh \
+                        --header "Authorization: Bearer ${CONTEXT7_API_KEY}" \
+                        --header "Content-Type: application/json" \
+                        --data '{"libraryName":"/llmstxt/feeds_dragon-code_pro_llms_txt"}'

--- a/tests/Unit/DocumentationWorkflowTest.php
+++ b/tests/Unit/DocumentationWorkflowTest.php
@@ -28,6 +28,17 @@ function documentationActionStep(array $steps, string $action): array
     throw new RuntimeException("Documentation workflow action not found: [$action].");
 }
 
+function documentationRunStep(array $steps, string $command): array
+{
+    foreach ($steps as $step) {
+        if (str_contains($step['run'] ?? '', $command)) {
+            return $step;
+        }
+    }
+
+    throw new RuntimeException("Documentation workflow command not found: [$command].");
+}
+
 function expectDocumentationActionsPinned(array $steps): void
 {
     foreach ($steps as $step) {
@@ -44,16 +55,18 @@ function expectDocumentationActionsPinned(array $steps): void
 test('builds and deploys Docusaurus through GitHub Pages', function () {
     [$workflow, $contents] = loadDocumentationWorkflow('docs.yml');
 
-    $build       = $workflow['jobs']['build'];
-    $deploy      = $workflow['jobs']['deploy'];
-    $buildSteps  = $build['steps'];
-    $deploySteps = $deploy['steps'];
-    $checkout    = documentationActionStep($buildSteps, 'actions/checkout');
-    $setupNode   = documentationActionStep($buildSteps, 'actions/setup-node');
-    $upload      = documentationActionStep($buildSteps, 'actions/upload-pages-artifact');
-    $deployment  = documentationActionStep($deploySteps, 'actions/deploy-pages');
-    $refresh     = $deploySteps[1];
-    $commands    = array_column($buildSteps, 'run');
+    $build         = $workflow['jobs']['build'];
+    $deploy        = $workflow['jobs']['deploy'];
+    $context7      = $workflow['jobs']['context7'];
+    $buildSteps    = $build['steps'];
+    $deploySteps   = $deploy['steps'];
+    $context7Steps = $context7['steps'];
+    $checkout      = documentationActionStep($buildSteps, 'actions/checkout');
+    $setupNode     = documentationActionStep($buildSteps, 'actions/setup-node');
+    $upload        = documentationActionStep($buildSteps, 'actions/upload-pages-artifact');
+    $deployment    = documentationActionStep($deploySteps, 'actions/deploy-pages');
+    $refresh       = documentationRunStep($context7Steps, 'https://context7.com/api/v1/refresh');
+    $commands      = array_column($buildSteps, 'run');
 
     expect($workflow['on']['push']['branches'])->toContain('main')
         ->and(array_key_exists('workflow_dispatch', $workflow['on']))->toBeTrue()
@@ -83,6 +96,8 @@ test('builds and deploys Docusaurus through GitHub Pages', function () {
         ])
         ->and($deploy['environment']['name'])->toBe('github-pages')
         ->and($deployment['id'])->toBe('deployment')
+        ->and($context7['needs'])->toBe('deploy')
+        ->and($context7['permissions'])->toBe(['id-token' => 'write'])
         ->and($refresh['env'])->toBe([
             'CONTEXT7_API_KEY' => '${{ secrets.CONTEXT7_API_KEY }}',
         ])
@@ -97,7 +112,7 @@ test('builds and deploys Docusaurus through GitHub Pages', function () {
         expect(strtolower($contents))->not->toContain($forbidden);
     }
 
-    expectDocumentationActionsPinned([...$buildSteps, ...$deploySteps]);
+    expectDocumentationActionsPinned([...$buildSteps, ...$deploySteps, ...$context7Steps]);
 });
 
 test('validates Docusaurus for documentation pull requests and manual runs', function () {

--- a/tests/Unit/DocumentationWorkflowTest.php
+++ b/tests/Unit/DocumentationWorkflowTest.php
@@ -102,11 +102,14 @@ test('builds and deploys Docusaurus through GitHub Pages', function () {
             'CONTEXT7_API_KEY' => '${{ secrets.CONTEXT7_API_KEY }}',
         ])
         ->and($refresh['run'])->toContain(
-            'curl --fail-with-body --silent --show-error',
+            'curl --silent --show-error',
             'https://context7.com/api/v1/refresh',
             'Authorization: Bearer ${CONTEXT7_API_KEY}',
             '{"libraryName":"/llmstxt/feeds_dragon-code_pro_llms_txt"}',
-        );
+            'user-has-active-task',
+            'exit 1',
+        )
+        ->and($refresh['run'])->not->toContain('--fail-with-body');
 
     foreach (['writerside', 'algolia', 'composer_token', 'ctx7sk-'] as $forbidden) {
         expect(strtolower($contents))->not->toContain($forbidden);

--- a/tests/Unit/DocumentationWorkflowTest.php
+++ b/tests/Unit/DocumentationWorkflowTest.php
@@ -41,7 +41,7 @@ function expectDocumentationActionsPinned(array $steps): void
     }
 }
 
-test('builds and deploys Docusaurus through GitHub Pages without secrets', function () {
+test('builds and deploys Docusaurus through GitHub Pages', function () {
     [$workflow, $contents] = loadDocumentationWorkflow('docs.yml');
 
     $build       = $workflow['jobs']['build'];
@@ -52,6 +52,7 @@ test('builds and deploys Docusaurus through GitHub Pages without secrets', funct
     $setupNode   = documentationActionStep($buildSteps, 'actions/setup-node');
     $upload      = documentationActionStep($buildSteps, 'actions/upload-pages-artifact');
     $deployment  = documentationActionStep($deploySteps, 'actions/deploy-pages');
+    $refresh     = $deploySteps[1];
     $commands    = array_column($buildSteps, 'run');
 
     expect($workflow['on']['push']['branches'])->toContain('main')
@@ -81,9 +82,18 @@ test('builds and deploys Docusaurus through GitHub Pages without secrets', funct
             'pages'    => 'write',
         ])
         ->and($deploy['environment']['name'])->toBe('github-pages')
-        ->and($deployment['id'])->toBe('deployment');
+        ->and($deployment['id'])->toBe('deployment')
+        ->and($refresh['env'])->toBe([
+            'CONTEXT7_API_KEY' => '${{ secrets.CONTEXT7_API_KEY }}',
+        ])
+        ->and($refresh['run'])->toContain(
+            'curl --fail-with-body --silent --show-error',
+            'https://context7.com/api/v1/refresh',
+            'Authorization: Bearer ${CONTEXT7_API_KEY}',
+            '{"libraryName":"/llmstxt/feeds_dragon-code_pro_llms_txt"}',
+        );
 
-    foreach (['writerside', 'algolia', 'composer_token', 'secrets.'] as $forbidden) {
+    foreach (['writerside', 'algolia', 'composer_token', 'ctx7sk-'] as $forbidden) {
         expect(strtolower($contents))->not->toContain($forbidden);
     }
 


### PR DESCRIPTION
## Summary

- trigger a Context7 refresh after a successful GitHub Pages deployment
- read the API key from the `CONTEXT7_API_KEY` Actions secret
- target the existing `/llmstxt/feeds_dragon-code_pro_llms_txt` library
- cover the workflow contract with the existing documentation workflow test

## Why

Context7 refreshes less popular libraries infrequently. Triggering a refresh from the documentation deployment keeps the indexed `llms.txt` source aligned with the published site.

## Validation

- `vendor/bin/pest tests/Unit/DocumentationWorkflowTest.php` — 2 tests passed, 65 assertions
- `vendor/bin/pint --test tests/Unit/DocumentationWorkflowTest.php` — passed
- YAML parsing with the installed `js-yaml` package — passed
- `git diff --check` — passed
- staged diff scan confirmed that no Context7 API key was committed

The live Context7 request reached the API but returned `user-has-active-task` because the account already had an indexing task in progress; a successful HTTP 200 enqueue could not be observed during validation.