### PR TITLE
Run documentation checks on pushes and deploy on releases

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,9 @@
 name: Documentation
 
 on:
-    push:
-        branches:
-            - main
-    workflow_dispatch:
+    release:
+        types:
+            - published
 
 concurrency:
     group: pages
@@ -28,6 +27,7 @@ jobs:
             -   name: Checkout code
                 uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
                 with:
+                    ref: ${{ github.sha }}
                     persist-credentials: false
 
             -   name: Setup Node.js

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -1,6 +1,12 @@
 name: Test Documentation
 
 on:
+    push:
+        paths:
+            - docs/**
+            - src/**
+            - .github/workflows/docs.yml
+            - .github/workflows/test-docs.yml
     pull_request:
         paths:
             - docs/**

--- a/tests/Unit/DocumentationWorkflowTest.php
+++ b/tests/Unit/DocumentationWorkflowTest.php
@@ -68,8 +68,9 @@ test('builds and deploys Docusaurus through GitHub Pages', function () {
     $refresh       = documentationRunStep($context7Steps, 'https://context7.com/api/v1/refresh');
     $commands      = array_column($buildSteps, 'run');
 
-    expect($workflow['on']['push']['branches'])->toContain('main')
-        ->and(array_key_exists('workflow_dispatch', $workflow['on']))->toBeTrue()
+    expect($workflow['on'])->toBe([
+        'release' => ['types' => ['published']],
+    ])
         ->and($workflow['permissions'])->toBe([])
         ->and($workflow['concurrency'])->toBe([
             'group'              => 'pages',
@@ -80,6 +81,7 @@ test('builds and deploys Docusaurus through GitHub Pages', function () {
             'pages'    => 'write',
         ])
         ->and($build['defaults']['run']['working-directory'])->toBe('docs')
+        ->and($checkout['with']['ref'])->toBe('${{ github.sha }}')
         ->and($checkout['with']['persist-credentials'])->toBeFalse()
         ->and($setupNode['uses'])->toBe('actions/setup-node@820762786026740c76f36085b0efc47a31fe5020')
         ->and($setupNode['with'])->toMatchArray([
@@ -118,7 +120,7 @@ test('builds and deploys Docusaurus through GitHub Pages', function () {
     expectDocumentationActionsPinned([...$buildSteps, ...$deploySteps, ...$context7Steps]);
 });
 
-test('validates Docusaurus for documentation pull requests and manual runs', function () {
+test('validates Docusaurus for documentation pushes, pull requests, and manual runs', function () {
     [$workflow, $contents] = loadDocumentationWorkflow('test-docs.yml');
 
     $build      = $workflow['jobs']['build'];
@@ -128,10 +130,10 @@ test('validates Docusaurus for documentation pull requests and manual runs', fun
     $commands   = array_column($steps, 'run');
     $eventNames = array_keys($workflow['on']);
 
-    expect($eventNames)->toContain('pull_request', 'workflow_dispatch')
-        ->and($eventNames)->not->toContain('push')
+    expect($eventNames)->toContain('push', 'pull_request', 'workflow_dispatch')
         ->and($workflow['permissions'])->toBe(['contents' => 'read'])
         ->and($workflow['concurrency']['cancel-in-progress'])->toBeTrue()
+        ->and($workflow['on']['push']['paths'])->toBe($workflow['on']['pull_request']['paths'])
         ->and($workflow['on']['pull_request']['paths'])->toContain(
             'docs/**',
             'src/**',


### PR DESCRIPTION
## Summary

- run documentation quality gates for pushes and pull requests that affect documentation inputs
- deploy GitHub Pages only when a release is published
- build the deployment from the commit SHA referenced by the release tag
- refresh Context7 only after a successful Pages deployment

## Why

Documentation was deployed and Context7 was refreshed after every merge to `main`. Deployment now follows published versions while documentation validation remains available before and after merging.

## Validation

- parsed all GitHub Actions workflow files with `js-yaml`
- verified workflow trigger and dependency invariants
- ran `npm run build`
- ran `npm run check:seo`
- ran `git diff --check`