### PR TITLE
Fix vulnerable documentation dependencies

### DIFF
--- a/.ai-factory/patches/2026-08-08-22.32.md
+++ b/.ai-factory/patches/2026-08-08-22.32.md
@@ -1,0 +1,28 @@
+# Documentation dependency advisories remained open on the latest Docusaurus
+
+**Date:** 2026-08-08 22:32
+**Files:** docs/package.json, docs/package-lock.json
+**Severity:** high
+
+## Problem
+
+Dependabot reported four high-severity advisories in the documentation dependency graph. The vulnerable leaf packages were `image-size@2.0.2`, `js-yaml@4.3.0`, and `nanoid@3.3.16`. The audit expanded these advisories to 20 affected Docusaurus graph nodes.
+
+## Root Cause
+
+The lock file resolved `js-yaml` and `nanoid` below their patched releases. Docusaurus 3.10.2 also depends on `image-size@^2.0.2`, while the archived upstream package has no patched release for its ICNS, JXL, and HEIF infinite-loop vulnerabilities.
+
+## Solution
+
+Overrode `js-yaml` with 4.3.1 and `nanoid` with 3.3.18. Preserved `js-yaml@3.15.1` for `@lhci/utils` because Lighthouse CI still uses the removed `safeLoad` API. Replaced Docusaurus's `image-size` dependency with the API-compatible `image-size-safe@2.0.3` package and updated `serialize-javascript` to 7.1.0. Regenerated the lock file and verified the complete documentation workflow under the pinned Node 24 Playwright container.
+
+## Prevention
+
+- Check open Dependabot alerts and `npm audit` together because graph-level audit counts can obscure the vulnerable leaf packages.
+- Preserve consumer API compatibility when applying transitive overrides across major package lines.
+- Inspect replacement package contents, install scripts, runtime dependencies, and malformed-input behavior before adopting a security fork.
+- Run documentation build, browser, accessibility, visual, and Lighthouse gates in the same container used by CI.
+
+## Tags
+
+`#documentation` `#dependencies` `#dependabot` `#npm` `#docusaurus` `#security` `#regression`

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -3663,6 +3663,19 @@
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
+        "node_modules/@docusaurus/mdx-loader/node_modules/image-size": {
+            "name": "image-size-safe",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/image-size-safe/-/image-size-safe-2.0.3.tgz",
+            "integrity": "sha512-M8prcBmr9nsXwZMC4RzuOM7qvkwvQO1fN+PRxC+D8mc4pMBj2/l0e/kF7s8y3GB10O9zMSUgHHU66Y8tigWIfw==",
+            "license": "MIT",
+            "bin": {
+                "image-size-safe": "bin/image-size-safe.js"
+            },
+            "engines": {
+                "node": ">=16.x"
+            }
+        },
         "node_modules/@docusaurus/module-type-aliases": {
             "version": "3.10.2",
             "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.2.tgz",
@@ -11580,18 +11593,6 @@
                 "node": ">= 4"
             }
         },
-        "node_modules/image-size": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
-            "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
-            "license": "MIT",
-            "bin": {
-                "image-size": "bin/image-size.js"
-            },
-            "engines": {
-                "node": ">=16.x"
-            }
-        },
         "node_modules/image-ssim": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/image-ssim/-/image-ssim-0.2.0.tgz",
@@ -12345,9 +12346,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
             "funding": [
                 {
                     "type": "github",
@@ -15787,9 +15788,9 @@
             "license": "ISC"
         },
         "node_modules/nanoid": {
-            "version": "3.3.16",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "funding": [
                 {
                     "type": "github",
@@ -19461,9 +19462,9 @@
             }
         },
         "node_modules/serialize-javascript": {
-            "version": "7.0.7",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.7.tgz",
-            "integrity": "sha512-YAy8Od6KV+uuwUuU50np8fGB/Aues6Y0nAhA9y/hId74PlKUcme4pXcBD46NWKr1Q4osN/iseZ17YqO1XfmI8g==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.0.tgz",
+            "integrity": "sha512-RNEqWOyhhUQYN9V1GfHwu9AR/g+NTciH6Z5u3/no6X3/w+04J2lVDL+svFQVXgXrEGBMG2puMVN3gq2SNGuTGw==",
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=20.0.0"

--- a/docs/package.json
+++ b/docs/package.json
@@ -56,7 +56,13 @@
         "typescript": "~6.0.3"
     },
     "overrides": {
-        "serialize-javascript": "7.0.7",
+        "@lhci/utils": {
+            "js-yaml": "3.15.1"
+        },
+        "image-size": "npm:image-size-safe@2.0.3",
+        "js-yaml": "4.3.1",
+        "nanoid": "3.3.18",
+        "serialize-javascript": "7.1.0",
         "tmp": "0.2.7",
         "uuid": "11.1.1"
     },


### PR DESCRIPTION
## Summary

- replace the vulnerable archived `image-size` package with the API-compatible `image-size-safe@2.0.3`
- update `js-yaml`, `nanoid`, and `serialize-javascript` to patched compatible releases
- preserve `js-yaml@3.15.1` for Lighthouse CI because it still uses the legacy `safeLoad` API

## Why

Dependabot reported four high-severity advisories in the documentation dependency graph. Docusaurus 3.10.2 still depends on `image-size@2.0.2`, whose upstream project has no patched release for the ICNS, JXL, and HEIF infinite-loop vulnerabilities.

## Impact

The documentation dependency graph now audits cleanly without changing the generated site or supported Node 24 toolchain.

## Validation

- `npm ci`
- `npm run typecheck`
- `npm run build`
- `npm run check:seo`
- `npm run test:browser` — 30 tests passed
- `npm run test:performance` — 6 Lighthouse runs passed
- `npm audit --audit-level=low` — 0 vulnerabilities
- malformed ICNS, JXL, and HEIF regression checks