### PR TITLE
Fix queue status colors in PowerShell

### DIFF
--- a/.ai-factory/patches/2026-08-09-18.17.md
+++ b/.ai-factory/patches/2026-08-09-18.17.md
@@ -1,0 +1,26 @@
+# Queue status colors lost the ANSI escape byte
+
+**Date:** 2026-08-09 18:17
+**Files:** src/Commands/FeedGenerateCommand.php, tests/Feature/Console/Generation/QueueTest.php
+**Severity:** low
+
+## Problem
+
+Decorated `feed:generate` output displayed `[32mQUEUED[39m` and `[33mSKIP[39m` instead of colored statuses.
+
+## Root Cause
+
+The command passed raw ANSI sequences from `Laravel\Prompts\Concerns\Colors` into Laravel's `twoColumnDetail` component. Termwind parses that component as HTML, and `DOMDocument` removes the ESC control byte while preserving the remaining color-code text.
+
+## Solution
+
+Replaced the raw ANSI strings with Symfony Console markup supported by the component and removed the redundant color trait and helper methods. Updated the existing queue test to force decorated output and assert the complete ANSI sequences.
+
+## Prevention
+
+- Use Symfony Console markup inside Laravel console components.
+- Test decorated command output with `--ansi` when status colors are part of the output contract.
+
+## Tags
+
+`#console` `#ansi` `#powershell` `#termwind` `#queue` `#regression`

--- a/.ai-factory/patches/2026-08-09-18.17.md
+++ b/.ai-factory/patches/2026-08-09-18.17.md
@@ -14,12 +14,12 @@ The command passed raw ANSI sequences from `Laravel\Prompts\Concerns\Colors` int
 
 ## Solution
 
-Replaced the raw ANSI strings with Symfony Console markup supported by the component and removed the redundant color trait and helper methods. Updated the existing queue test to force decorated output and assert the complete ANSI sequences.
+Replaced the raw ANSI strings with Symfony Console markup supported by the component and removed the redundant color trait and helper methods. Updated the existing queue test to verify complete ANSI sequences with `--ansi` and plain output without leaked control or markup sequences with `--no-ansi`.
 
 ## Prevention
 
 - Use Symfony Console markup inside Laravel console components.
-- Test decorated command output with `--ansi` when status colors are part of the output contract.
+- Test both `--ansi` and `--no-ansi` when status colors are part of the output contract.
 
 ## Tags
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "illuminate/filesystem": "^11.0 || ^12.0 || ^13.0",
         "illuminate/support": "^11.0 || ^12.0 || ^13.0",
         "laravel/agent-detector": "^2.0.2",
-        "laravel/prompts": "^0.3.6",
         "spatie/temporary-directory": "^2.3"
     },
     "require-dev": {

--- a/src/Commands/FeedGenerateCommand.php
+++ b/src/Commands/FeedGenerateCommand.php
@@ -17,7 +17,6 @@ use DragonCode\LaravelFeed\Services\GeneratorService;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Collection;
 use InvalidArgumentException;
-use Laravel\Prompts\Concerns\Colors;
 use RuntimeException;
 use SplFileObject;
 use SplTempFileObject;
@@ -44,8 +43,6 @@ use function trim;
 #[AsCommand('feed:generate', 'Generate XML feeds')]
 final class FeedGenerateCommand extends Command
 {
-    use Colors;
-
     private const AGENT_JSON_FLAGS = JSON_THROW_ON_ERROR
         | JSON_UNESCAPED_SLASHES
         | JSON_INVALID_UTF8_SUBSTITUTE;
@@ -249,14 +246,14 @@ final class FeedGenerateCommand extends Command
 
     protected function showSkippedFeed(string $feed): void
     {
-        $this->components->twoColumnDetail($feed, $this->textYellow('SKIP'));
+        $this->components->twoColumnDetail($feed, '<fg=yellow>SKIP</>');
     }
 
     protected function dispatchFeed(string $feed, ?FeedTarget $target): void
     {
         $this->components->twoColumnDetail(
             $this->executionName($feed, $target),
-            $this->textGreen('QUEUED'),
+            '<fg=green>QUEUED</>',
         );
 
         FeedJob::dispatch($feed, $target);
@@ -420,28 +417,6 @@ final class FeedGenerateCommand extends Command
         }
 
         return $id;
-    }
-
-    protected function textYellow(string $message): string
-    {
-        if ($this->option('no-ansi')) {
-            // @codeCoverageIgnoreStart
-            return $message;
-            // @codeCoverageIgnoreEnd
-        }
-
-        return $this->yellow($message);
-    }
-
-    protected function textGreen(string $message): string
-    {
-        if ($this->option('no-ansi')) {
-            // @codeCoverageIgnoreStart
-            return $message;
-            // @codeCoverageIgnoreEnd
-        }
-
-        return $this->green($message);
     }
 
     protected function usesProgressBar(): bool

--- a/tests/Feature/Console/Generation/QueueTest.php
+++ b/tests/Feature/Console/Generation/QueueTest.php
@@ -26,9 +26,9 @@ test('queue', function () {
 
     Queue::fake()->serializeAndRestore();
 
-    artisan(FeedGenerateCommand::class)
-        ->expectsOutputToContain('QUEUED')
-        ->expectsOutputToContain('SKIP')
+    artisan(FeedGenerateCommand::class, ['--ansi' => true])
+        ->expectsOutputToContain("\e[32mQUEUED\e[39m")
+        ->expectsOutputToContain("\e[33mSKIP\e[39m")
         ->assertSuccessful()
         ->run();
 

--- a/tests/Feature/Console/Generation/QueueTest.php
+++ b/tests/Feature/Console/Generation/QueueTest.php
@@ -49,6 +49,16 @@ test('queue', function () {
         FeedJob::class,
         fn (FeedJob $job) => in_array($job->feedClass, [SitemapFeed::class, YandexFeed::class], true)
     );
+
+    artisan(FeedGenerateCommand::class, ['--no-ansi' => true])
+        ->expectsOutputToContain('QUEUED')
+        ->expectsOutputToContain('SKIP')
+        ->doesntExpectOutputToContain("\e[")
+        ->doesntExpectOutputToContain('[32mQUEUED[39m')
+        ->doesntExpectOutputToContain('[33mSKIP[39m')
+        ->doesntExpectOutputToContain('<fg=')
+        ->assertSuccessful()
+        ->run();
 });
 
 test('does not resolve an ordinary feed before queueing', function () {


### PR DESCRIPTION
## Summary

- render `QUEUED` and `SKIP` through Symfony Console markup
- remove raw ANSI helpers that were corrupted by Termwind HTML rendering
- verify colored output with `--ansi` and plain output with `--no-ansi`
- remove the now-unused direct `laravel/prompts` dependency

## Root cause

Raw ESC sequences from `Laravel\Prompts\Concerns\Colors` were passed into Laravel's `twoColumnDetail()` component. Termwind parsed the component as HTML, and DOM parsing removed the ESC byte while leaving `[32mQUEUED[39m` and `[33mSKIP[39m` visible in PowerShell.

`Laravel\Prompts\Concerns\Colors` itself is not defective. Its raw ANSI output is unsuitable inside this HTML-rendered component. Symfony Console markup is the native component format and respects both `--ansi` and `--no-ansi`.

## Impact

Queue generation statuses render with the intended colors. `--no-ansi` produces plain status text without ANSI or markup fragments. The package no longer declares `laravel/prompts` as a direct runtime dependency; Laravel applications may still install it transitively through the framework.

## Validation

- `vendor\bin\pest` — 433 tests passed, 2238 assertions
- `composer validate --strict` — passed
- `composer normalize --dry-run` — passed
- `composer update --no-dev --dry-run --no-interaction` — dependency resolution passed