### PR TITLE
docs: sync targeted feed snippet formatting

### DIFF
--- a/.ai-factory/patches/2026-08-10-13.56.md
+++ b/.ai-factory/patches/2026-08-10-13.56.md
@@ -1,0 +1,27 @@
+# Documentation snippet formatting broke the release build
+
+**Date:** 2026-08-10 13:56
+**Files:** `docs/docs/receipt-target-feeds.mdx`, `docs/i18n/*/docusaurus-plugin-content-docs/current/receipt-target-feeds.mdx`, `docs/static/llms.txt`
+**Severity:** medium
+
+## Problem
+
+The documentation release failed in `npm run check:snippets` because the embedded `receipt-target-feeds.mdx` code differed from `docs/snippets/targeted-feed.php`.
+
+## Root Cause
+
+The code-style commit formatted the PHP snippet after the documentation checks had passed, but did not update the English code fence, its eight localized copies, or the generated LLM document.
+
+## Solution
+
+Synchronized the formatted line across the English page, all maintained localizations, and the generated LLM document. Verified the fix with the original snippet check and the full production build.
+
+## Prevention
+
+- Run `npm run check:snippets` after formatting files under `docs/snippets`.
+- Keep referenced code fences identical across the English source and every localization.
+- Regenerate `docs/static/llms.txt` after documentation code changes.
+
+## Tags
+
+`#documentation` `#snippets` `#i18n` `#github-actions` `#regression`

--- a/docs/docs/receipt-target-feeds.mdx
+++ b/docs/docs/receipt-target-feeds.mdx
@@ -55,7 +55,7 @@ class ProductFeed extends Feed implements HasFeedTargets
     use InteractsWithFeedTargets;
 
     private const TARGETS = [
-        'available' => ['in_stock' => true],
+        'available'   => ['in_stock' => true],
         'unavailable' => ['in_stock' => false],
     ];
 

--- a/docs/i18n/be/docusaurus-plugin-content-docs/current/receipt-target-feeds.mdx
+++ b/docs/i18n/be/docusaurus-plugin-content-docs/current/receipt-target-feeds.mdx
@@ -55,7 +55,7 @@ class ProductFeed extends Feed implements HasFeedTargets
     use InteractsWithFeedTargets;
 
     private const TARGETS = [
-        'available' => ['in_stock' => true],
+        'available'   => ['in_stock' => true],
         'unavailable' => ['in_stock' => false],
     ];
 

--- a/docs/i18n/de/docusaurus-plugin-content-docs/current/receipt-target-feeds.mdx
+++ b/docs/i18n/de/docusaurus-plugin-content-docs/current/receipt-target-feeds.mdx
@@ -55,7 +55,7 @@ class ProductFeed extends Feed implements HasFeedTargets
     use InteractsWithFeedTargets;
 
     private const TARGETS = [
-        'available' => ['in_stock' => true],
+        'available'   => ['in_stock' => true],
         'unavailable' => ['in_stock' => false],
     ];
 

--- a/docs/i18n/fr/docusaurus-plugin-content-docs/current/receipt-target-feeds.mdx
+++ b/docs/i18n/fr/docusaurus-plugin-content-docs/current/receipt-target-feeds.mdx
@@ -55,7 +55,7 @@ class ProductFeed extends Feed implements HasFeedTargets
     use InteractsWithFeedTargets;
 
     private const TARGETS = [
-        'available' => ['in_stock' => true],
+        'available'   => ['in_stock' => true],
         'unavailable' => ['in_stock' => false],
     ];
 

--- a/docs/i18n/ko/docusaurus-plugin-content-docs/current/receipt-target-feeds.mdx
+++ b/docs/i18n/ko/docusaurus-plugin-content-docs/current/receipt-target-feeds.mdx
@@ -55,7 +55,7 @@ class ProductFeed extends Feed implements HasFeedTargets
     use InteractsWithFeedTargets;
 
     private const TARGETS = [
-        'available' => ['in_stock' => true],
+        'available'   => ['in_stock' => true],
         'unavailable' => ['in_stock' => false],
     ];
 

--- a/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/receipt-target-feeds.mdx
+++ b/docs/i18n/pt-BR/docusaurus-plugin-content-docs/current/receipt-target-feeds.mdx
@@ -55,7 +55,7 @@ class ProductFeed extends Feed implements HasFeedTargets
     use InteractsWithFeedTargets;
 
     private const TARGETS = [
-        'available' => ['in_stock' => true],
+        'available'   => ['in_stock' => true],
         'unavailable' => ['in_stock' => false],
     ];
 

--- a/docs/i18n/ru/docusaurus-plugin-content-docs/current/receipt-target-feeds.mdx
+++ b/docs/i18n/ru/docusaurus-plugin-content-docs/current/receipt-target-feeds.mdx
@@ -55,7 +55,7 @@ class ProductFeed extends Feed implements HasFeedTargets
     use InteractsWithFeedTargets;
 
     private const TARGETS = [
-        'available' => ['in_stock' => true],
+        'available'   => ['in_stock' => true],
         'unavailable' => ['in_stock' => false],
     ];
 

--- a/docs/i18n/uk/docusaurus-plugin-content-docs/current/receipt-target-feeds.mdx
+++ b/docs/i18n/uk/docusaurus-plugin-content-docs/current/receipt-target-feeds.mdx
@@ -55,7 +55,7 @@ class ProductFeed extends Feed implements HasFeedTargets
     use InteractsWithFeedTargets;
 
     private const TARGETS = [
-        'available' => ['in_stock' => true],
+        'available'   => ['in_stock' => true],
         'unavailable' => ['in_stock' => false],
     ];
 

--- a/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/receipt-target-feeds.mdx
+++ b/docs/i18n/zh-CN/docusaurus-plugin-content-docs/current/receipt-target-feeds.mdx
@@ -55,7 +55,7 @@ class ProductFeed extends Feed implements HasFeedTargets
     use InteractsWithFeedTargets;
 
     private const TARGETS = [
-        'available' => ['in_stock' => true],
+        'available'   => ['in_stock' => true],
         'unavailable' => ['in_stock' => false],
     ];
 

--- a/docs/static/llms.txt
+++ b/docs/static/llms.txt
@@ -2427,7 +2427,7 @@ class ProductFeed extends Feed implements HasFeedTargets
     use InteractsWithFeedTargets;
 
     private const TARGETS = [
-        'available' => ['in_stock' => true],
+        'available'   => ['in_stock' => true],
         'unavailable' => ['in_stock' => false],
     ];
 


### PR DESCRIPTION
## Summary

- synchronize the targeted feed code fence with the Pint-formatted PHP snippet
- apply the same code block to all eight maintained localizations
- regenerate `docs/static/llms.txt`

## Root cause

PR #256 formatted `docs/snippets/targeted-feed.php` after PR #255 had passed its documentation checks. The English MDX page and localized copies retained the previous spacing, so `check:snippets` rejected the release build.

## Validation

- `npm run check:snippets`
- `npm run build`
- `npm run check:seo`
- `vendor/bin/pint --test docs/snippets/targeted-feed.php`