### PR TITLE
Move feed staging to the system temp directory

### DIFF
--- a/.ai-factory/patches/2026-08-11-21.24.md
+++ b/.ai-factory/patches/2026-08-11-21.24.md
@@ -1,0 +1,27 @@
+# Local feed staging polluted target directories after interrupted generation
+
+**Date:** 2026-08-11 21:24
+**Files:** `src/Services/FilesystemService.php`, `tests/Unit/Services/FilesystemServiceTest.php`, `tests/Unit/Services/FilesystemServiceFailureTest.php`
+**Severity:** medium
+
+## Problem
+
+Local feed generation created `.feeds_staging_*` directories beside the publication target. A process interruption could leave generated drafts and backups in the user-facing target directory.
+
+## Root Cause
+
+`FilesystemService::createStagingDirectory()` used `dirname($path)` as the staging location even though the service already used `sys_get_temp_dir()` for other local temporary files.
+
+## Solution
+
+Local publication staging now uses `sys_get_temp_dir()`. Regression coverage verifies the location, cleanup, collision handling, and rollback-failure fixture isolation.
+
+## Prevention
+
+- Keep generated drafts and backups outside user-facing target directories.
+- Assert the actual staging path instead of inferring cleanup from target-directory globs.
+- Isolate rollback tests that intentionally preserve staging so they do not pollute the shared system temp directory.
+
+## Tags
+
+`#filesystem` `#staging` `#temporary-directory` `#feed-generation` `#regression`

--- a/src/Services/FilesystemService.php
+++ b/src/Services/FilesystemService.php
@@ -525,7 +525,7 @@ class FilesystemService
             $this->file->ensureDirectoryExists(dirname($path));
 
             return $this->createTemporaryDirectory(
-                dirname($path),
+                sys_get_temp_dir(),
                 fn () => '.feeds_staging_' . $this->uniqueIdentifier()
             );
         } catch (Throwable $e) {

--- a/tests/Unit/Services/FilesystemServiceFailureTest.php
+++ b/tests/Unit/Services/FilesystemServiceFailureTest.php
@@ -273,6 +273,17 @@ function failureDraft(FilesystemService $service, string $staging, string $targe
     return $service->finishDraft($draft);
 }
 
+function failureLocalService(FailureModeFilesystem $file, TemporaryDirectory $directory): FailureModeFilesystemService
+{
+    $service                    = new FailureModeFilesystemService($file);
+    $service->controlledStaging = (new TemporaryDirectory)
+        ->location($directory->path())
+        ->name('staging')
+        ->create();
+
+    return $service;
+}
+
 function failureOwnershipPath(string $publication): string
 {
     return dirname($publication) . DIRECTORY_SEPARATOR . '.laravel-feeds' . DIRECTORY_SEPARATOR . 'ownership.json';
@@ -584,7 +595,7 @@ test('preserves local staging when rollback cannot remove an installed feed', fu
     $file                           = new FailureModeFilesystem;
     $file->failMoveTargets[$second] = 1;
     $file->failDeletes[$first]      = 1;
-    $service                        = new FilesystemService($file);
+    $service                        = failureLocalService($file, $directory);
 
     try {
         expect(fn () => $service->publish($publication, fn (string $staging) => [
@@ -606,7 +617,7 @@ test('reports a rollback failure when the replaced feed cannot be cleared', func
     $file                              = new FailureModeFilesystem;
     $file->failMoveTargets[$ownership] = 1;
     $file->failDeletes[$publication]   = 2;
-    $service                           = new FilesystemService($file);
+    $service                           = failureLocalService($file, $directory);
 
     file_put_contents($publication, 'old');
 
@@ -629,7 +640,7 @@ test('reports a rollback failure when a backup cannot be restored', function () 
     $file                                     = new FailureModeFilesystem;
     $file->failMoveTargets[$ownership]        = 1;
     $file->failBackupRestoresTo[$publication] = true;
-    $service                                  = new FilesystemService($file);
+    $service                                  = failureLocalService($file, $directory);
 
     file_put_contents($publication, 'old');
 

--- a/tests/Unit/Services/FilesystemServiceTest.php
+++ b/tests/Unit/Services/FilesystemServiceTest.php
@@ -218,16 +218,18 @@ test('treats empty content as a no-op', function () {
     }
 });
 
-test('creates collision-resistant drafts and cleans the staging directory', function () {
-    $directory = (new TemporaryDirectory)->create();
-    $path      = $directory->path('feed.json');
-    $drafts    = [];
+test('creates collision-resistant drafts in system temp and cleans the staging directory', function () {
+    $directory   = (new TemporaryDirectory)->create();
+    $path        = $directory->path('feed.json');
+    $drafts      = [];
+    $stagingPath = null;
 
     try {
-        (new FilesystemService(new Filesystem))->publish($path, function (string $staging) use (&$drafts, $path) {
-            $service = new FilesystemService(new Filesystem);
-            $first   = $service->createDraft('feed.json', $staging);
-            $second  = $service->createDraft('feed.json', $staging);
+        (new FilesystemService(new Filesystem))->publish($path, function (string $staging) use (&$drafts, &$stagingPath, $path) {
+            $stagingPath = $staging;
+            $service     = new FilesystemService(new Filesystem);
+            $first       = $service->createDraft('feed.json', $staging);
+            $second      = $service->createDraft('feed.json', $staging);
 
             $drafts[] = $service->finishDraft($first);
             $drafts[] = $service->finishDraft($second);
@@ -237,6 +239,10 @@ test('creates collision-resistant drafts and cleans the staging directory', func
 
         expect($drafts[0])
             ->not->toBe($drafts[1])
+            ->and(dirname($stagingPath))
+            ->toBe(rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR))
+            ->and($stagingPath)
+            ->not->toBeDirectory()
             ->and($path)
             ->toBeFile()
             ->and(glob($directory->path() . DIRECTORY_SEPARATOR . '.feeds_staging_*'))
@@ -400,26 +406,27 @@ test('keeps draft paths independent from output filenames', function () {
 test('retries staging creation without removing the colliding directory', function () {
     $directory = (new TemporaryDirectory)->create();
     $path      = $directory->path('feed.json');
-    $collision = $directory->path() . DIRECTORY_SEPARATOR . '.feeds_staging_collision';
+    $prefix    = bin2hex(random_bytes(8));
+    $collision = sys_get_temp_dir() . DIRECTORY_SEPARATOR . ".feeds_staging_{$prefix}_collision";
     $sentinel  = $collision . DIRECTORY_SEPARATOR . 'sentinel.txt';
 
     mkdir($collision);
     file_put_contents($sentinel, 'existing');
 
     ControlledIdentifierFilesystemService::reset(
-        'collision',
-        'staging',
-        'draft_directory',
-        'draft_file',
-        'ownership_directory',
-        'ownership_file'
+        "{$prefix}_collision",
+        "{$prefix}_staging",
+        "{$prefix}_draft_directory",
+        "{$prefix}_draft_file",
+        "{$prefix}_ownership_directory",
+        "{$prefix}_ownership_file"
     );
 
     try {
         $service = new ControlledIdentifierFilesystemService(new Filesystem);
 
-        $service->publish($path, function (string $staging) use ($path, $service) {
-            expect(basename($staging))->toBe('.feeds_staging_staging');
+        $service->publish($path, function (string $staging) use ($path, $prefix, $service) {
+            expect(basename($staging))->toBe(".feeds_staging_{$prefix}_staging");
 
             $draft = $service->createDraft('feed.json', $staging);
             $service->append($draft, 'published', $path);
@@ -431,9 +438,13 @@ test('retries staging creation without removing the colliding directory', functi
             ->toBe('published')
             ->and(file_get_contents($sentinel))
             ->toBe('existing')
+            ->and($collision)
+            ->toBeDirectory()
             ->and(glob($directory->path() . DIRECTORY_SEPARATOR . '.feeds_staging_*'))
-            ->toBe([$collision]);
+            ->toBe([]);
     } finally {
+        (new Filesystem)->deleteDirectory($collision);
+
         $directory->delete();
     }
 });


### PR DESCRIPTION
## Summary

- create local feed staging directories under `sys_get_temp_dir()`
- verify staging cleanup and collision handling in the system temp directory
- isolate rollback tests that intentionally preserve staging artifacts

## Root cause

Local publication staging used the target file directory, so an interrupted generation could leave `.feeds_staging_*` artifacts beside user-facing feed files.

## Impact

Interrupted local feed generation no longer pollutes the target directory. Remote storage staging behavior is unchanged.

## Validation

- `vendor\bin\pest --colors=never`
- 433 tests passed, 2241 assertions