### PR TITLE
Fix inline code padding

### DIFF
--- a/docs/src/css/docusaurus-overrides.css
+++ b/docs/src/css/docusaurus-overrides.css
@@ -93,6 +93,7 @@
 }
 
 .theme-doc-markdown :not(pre) > code {
+    padding: 2px 6px;
     border: 1px solid var(--color-border);
     background: var(--color-code-bg);
     color: var(--color-text);


### PR DESCRIPTION
## What changed

Added `padding: 2px 6px` to inline code elements inside documentation content.

## Why

Inline code had no horizontal padding, which made the highlight appear compressed against its text.

## Impact

Inline code is easier to read without affecting fenced code blocks.

## Checks

- `git diff --cached --check`
- `npm run build`